### PR TITLE
Upgrades expansion

### DIFF
--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -7,7 +7,6 @@
                 <!-- every special tab will look way different, but also this isnt where this shit will
                 display, so who cares lmao. -->
                 <br />
-                <button @click="mapStore.nodes[3].hidden = true">Hide node 4</button>
             </div>
             <div v-show="!mapStore.isSpecial">
                 {{ mapStore.getDescription }} {{ mapStore.getDescAppend }}
@@ -42,11 +41,25 @@ onPaneReady((instance) => {
     instance.setCenter(0, 0, {zoom: 1})
     mapStore.selectedNode = findNode("1")!;
     nodes.value.forEach(element => {
-        if(element.data?.killCount.gte(element.data?.scoutThreshold)) {
+        if(element.data?.killCount?.gte(element.data?.scoutThreshold)) {
             element.hidden = false;
             element.data.intereactable = true;
-            //Add !hidden to all edges grabbed by this function.
-            const edges = getConnectedEdges(element.id) 
+            //Add !hidden and interactable to all edges and nodes grabbed by this function.
+            const edges = getConnectedEdges(element.id);
+            edges.forEach(element => {
+                let node = findNode(element.target);
+                if(node) {
+                    node.hidden = false;
+                    node.data.interactable = true;
+                    let secondEdges = getConnectedEdges(node.id);
+                    secondEdges.forEach(innerEl => {
+                        let innerNode = findNode(innerEl.target);
+                        if(innerNode) {
+                            innerNode.hidden = false;
+                        }
+                    })
+                }
+            })
         }
     });
 })

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -1,19 +1,19 @@
 <template>
     <div id="maps_container">
         <div id="map_keynodes">
-            {{ mapStuff.getAreaName }} <br />
-            <div v-show="mapStuff.isSpecial">
+            {{ mapStore.getAreaName }} <br />
+            <div v-show="mapStore.isSpecial">
                 special 
                 <!-- every special tab will look way different, but also this isnt where this shit will
                 display, so who cares lmao. -->
                 <br />
-                <button @click="mapStuff.elements[3].hidden = true">Hide node 4</button>
+                <button @click="mapStore.nodes[3].hidden = true">Hide node 4</button>
             </div>
-            <div v-show="!mapStuff.isSpecial">
-                {{ mapStuff.getDescription }} {{ mapStuff.getDescAppend }}
+            <div v-show="!mapStore.isSpecial">
+                {{ mapStore.getDescription }} {{ mapStore.getDescAppend }}
             </div>
         </div>
-        <VueFlow v-model="mapStuff.elements" class="general_outline">
+        <VueFlow :nodes="mapStore.nodes" class="general_outline">
 
         </VueFlow>
     </div>
@@ -23,29 +23,35 @@
 <script setup lang="ts">
 import { useMapStore } from '@/stores/mapStore.js';
 import { VueFlow, useVueFlow } from '@vue-flow/core';
-import { Zone } from '@/enums/areaEnums'
+import { Zone } from '@/enums/areaEnums';
+import { watch } from 'vue';
 
 const name = "overmappanel";
-const mapStuff = useMapStore();
+const mapStore = useMapStore();
 
-const { nodesDraggable, onPaneReady, elementsSelectable, onNodeClick, findNode, findEdge, getConnectedEdges } = useVueFlow();
+const { nodesDraggable, onPaneReady, elementsSelectable, onNodeClick, 
+    findNode, findEdge, getConnectedEdges, addEdges } = useVueFlow();
 onPaneReady((instance) => {
+    addEdges(mapStore.edges);
     nodesDraggable.value = false;
     elementsSelectable.value = true;
     instance.setCenter(0, 0, {zoom: 1})
-    mapStuff.selectedNode = findNode("1")!;
+    mapStore.selectedNode = findNode("1")!;
 })
 onNodeClick((node) => {
     //Check adjacency.
-    const isConnected = getConnectedEdges(mapStuff.selectedNode.id).find( 
+    const isConnected = getConnectedEdges(mapStore.selectedNode.id).find( 
         connection => (connection.target === node.node.id || connection.source === node.node.id)
     )
 
     if (isConnected) {
-        mapStuff.selectedNode = findNode(node.node.id)!;
-        mapStuff.setTextAppend()
-        mapStuff.callRandomEncounter(Zone.FOREST)
+        mapStore.selectedNode = findNode(node.node.id)!;
+        mapStore.setTextAppend()
+        mapStore.callRandomEncounter(Zone.FOREST)
     }
 })
+
+
+
 
 </script>

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -83,8 +83,7 @@ const refreshMap = function() {
         if(element.data?.killCount >= element.data?.scoutThreshold) {
             element.hidden = false;
             element.data.intereactable = true;
-            
-            //TODO: make this a function
+
             scoutRevealNodes(element);
         }
     });
@@ -93,7 +92,6 @@ const refreshMap = function() {
 
 const { scouted$ } = storeToRefs(mapStore)
 
-//Signals
 watch(scouted$, (signal) => {
     if(signal === "$REFRESH$") {
         refreshMap();

--- a/src/components/UpgradeButton.vue
+++ b/src/components/UpgradeButton.vue
@@ -36,7 +36,7 @@ let props = defineProps({
 const currType = props.type;
 
 const canAfford = function() {
-    //TODO: switch case here, to set the :disabled="" section above to enoughSoul/areasScounted/etc
+    //TODO: switch case here, to set the :disabled="" section above to enoughSoul/areasScouted/etc
 }
 
 const buy = function() {

--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -4,6 +4,7 @@ import Decimal from 'break_infinity.js'
 import { readonly } from 'vue';
 import { usePlayer } from '@/stores/player';
 import type { CarouselItem } from '../types/carouselItem';
+import { useMapStore } from './mapStore';
 
 export const useCombatStore = defineStore('combat', {
     state: () => ({
@@ -67,6 +68,8 @@ export const useCombatStore = defineStore('combat', {
             else if(this.currentHP.lte(0)) {
                 this.pushToCombatLog("Victory! Gained " + this.currentOpponent.soulKill + " Soul.")
                 player.addSoul(this.currentOpponent.soulKill);
+                const mapStore = useMapStore();
+                mapStore.addKills(1);
                 this.endCombat();
             }
             else if(this.carouselArray[0].type === "player") {

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -19,6 +19,7 @@ soulKill: new Decimal(""),
 export const useMapStore = defineStore('mapStuff', {
     state: () => ({
         encounterSignal$: {} as Enemy,
+        scouted$: "",
         selectedNode: {data: {}} as GraphNode,
         enemyList: [
             {
@@ -62,8 +63,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Home",
                     zone: Zone.FOREST,
                     description: "You can just put whatever here.",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("0")
+                    killCount: 0,
+                    scoutThreshold: 0
                 } as AreaData
             },
             {
@@ -75,8 +76,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Dense Foliage",
                     zone: Zone.FOREST,
                     description: "this be some dense foliage",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("1")
+                    killCount: 0,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -88,8 +89,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("1")
+                    killCount: 0,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -101,8 +102,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("1")
+                    killCount: 0,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -114,8 +115,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("1")
+                    killCount: 0,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -127,8 +128,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
-                    killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("1")
+                    killCount: 0,
+                    scoutThreshold: 1
                 } as AreaData
             },
         ],
@@ -210,17 +211,17 @@ export const useMapStore = defineStore('mapStuff', {
 
         //this just adds kills to the current node, but should be easy to expand to add elsewhere
         //if we do stuff that'd allow it later
-        addKills(amnt:Decimal|number) {
+        addKills(amnt:number) {
             if(this.hasData) {
-                if(this.selectedNode.data.killCount.lt(this.selectedNode.data.scoutThreshold)) {
+                if(this.selectedNode.data.killCount < this.selectedNode.data.scoutThreshold) {
                     let node = this.nodes.find(item => item.id === this.selectedNode.id)
-      
-                    if(node?.data?.killCount) {
-                        console.log(node.data.killCount.toString())
-                        node.data.killCount = Decimal.add(node.data.killCount, amnt);
-                        console.log(node.data.killCount.toString())
-                        if(node.data.killCount.gte(node.data.scoutThreshold)) {
-                            
+                    console.log(node)
+                    console.log(node?.data.killCount)
+                    if(node) {
+                        // node.data.killCount = Decimal.add(node.data.killCount, amnt);
+                        node.data.killCount += amnt
+                        if(node.data.killCount >= node.data.scoutThreshold) {
+                            this.scouted$ = node.id;
                         }
                     }
                     else {console.log("Couldn't update killcount. addKills()")}

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -218,7 +218,6 @@ export const useMapStore = defineStore('mapStuff', {
                     console.log(node)
                     console.log(node?.data.killCount)
                     if(node) {
-                        // node.data.killCount = Decimal.add(node.data.killCount, amnt);
                         node.data.killCount += amnt
                         if(node.data.killCount >= node.data.scoutThreshold) {
                             this.scouted$ = node.id;

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -50,7 +50,7 @@ export const useMapStore = defineStore('mapStuff', {
             }
         ] as Array<Enemy>,
 
-        elements: [
+        nodes: [
             {
                 id: '1',
                 type: 'input',
@@ -62,6 +62,8 @@ export const useMapStore = defineStore('mapStuff', {
                     areaName: "Home",
                     zone: Zone.FOREST,
                     description: "You can just put whatever here.",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("0")
                 } as AreaData
             },
             {
@@ -72,7 +74,9 @@ export const useMapStore = defineStore('mapStuff', {
                 data: {
                     areaName: "Dense Foliage",
                     zone: Zone.FOREST,
-                    description: "this be some dense foliage"
+                    description: "this be some dense foliage",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("0")
                 } as AreaData
             },
             {
@@ -83,7 +87,9 @@ export const useMapStore = defineStore('mapStuff', {
                 data: {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
-                    description: "A specific clearing description."
+                    description: "A specific clearing description.",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("0")
                 } as AreaData
             },
             {
@@ -93,6 +99,8 @@ export const useMapStore = defineStore('mapStuff', {
                 class: 'light',
                 hidden: false,
             },
+        ],
+        edges: [
             { id: 'e1-2', source: '1', target: '2' },
             { id: 'e1-3', source: '1', target: '3' },
             { id: 'e3-4', source: '3', target: '4' },
@@ -129,6 +137,12 @@ export const useMapStore = defineStore('mapStuff', {
         getDescAppend(): string {
             return this.hasData ? this.areaData.random.descAppend  : "";
         },
+        getKillCount(): Decimal {
+            return this.hasData ? this.selectedNode.data.killCount : "";
+        },
+        scouted(): Boolean {
+            return (this.getKillCount.gte(this.selectedNode.data.scoutThreshold))
+        },
         hasData(): Boolean {
             return Object.keys(this.selectedNode.data).length !== 0
         },
@@ -155,6 +169,21 @@ export const useMapStore = defineStore('mapStuff', {
                 case Zone.FOREST: {
                     const encounterIdx = Math.floor(Math.random() * this.enemyList.length );
                     this.encounterSignal$ = this.enemyList[encounterIdx];
+                }
+            }
+        },
+
+        //this just adds kills to the current node, but should be easy to expand to add elsewhere
+        //if we do stuff that'd allow it later
+        addKills(amnt:Decimal|number) {
+            if(this.hasData) {
+                if(this.selectedNode.data.killCount.lt(this.selectedNode.data.scoutThreshold)) {
+                    let node = this.nodes.find(item => item.id === this.selectedNode.id)
+      
+                    if(node?.data?.killCount) {
+                      node.data.killCount = Decimal.add(node.data.killCount, amnt);
+                    }
+                    else {console.log("Couldn't update killcount. addKills()")}
                 }
             }
         }

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -220,24 +220,7 @@ export const useMapStore = defineStore('mapStuff', {
                         node.data.killCount = Decimal.add(node.data.killCount, amnt);
                         console.log(node.data.killCount.toString())
                         if(node.data.killCount.gte(node.data.scoutThreshold)) {
-                            //TODO: make function for this later
-                            const { getConnectedEdges, findNode } = useVueFlow();
-                            const mapEdges = getConnectedEdges(node.id);
-                            console.log(mapEdges)
-                            mapEdges.forEach(element => {
-                                let node = findNode(element.target);
-                                if(node) {
-                                    node.hidden = false;
-                                    node.data.interactable = true;
-                                    let secondEdges = getConnectedEdges(node.id);
-                                    secondEdges.forEach(innerEl => {
-                                        let innerNode = findNode(innerEl.target);
-                                        if(innerNode) {
-                                            innerNode.hidden = false;
-                                        }
-                                    })
-                                }
-                            })
+                            
                         }
                     }
                     else {console.log("Couldn't update killcount. addKills()")}

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import Decimal from 'break_infinity.js'
 import type { Enemy } from '@/types/enemy'
-import type { GraphNode } from '@vue-flow/core'
+import { useVueFlow, type GraphNode } from '@vue-flow/core'
 import type { AreaData } from '@/types/areaData'
 import { SpecialAreaId, Zone } from '@/enums/areaEnums'
 
@@ -76,7 +76,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "this be some dense foliage",
                     killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("0")
+                    scoutThreshold: new Decimal("1")
                 } as AreaData
             },
             {
@@ -89,21 +89,56 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: new Decimal("0"),
-                    scoutThreshold: new Decimal("0")
+                    scoutThreshold: new Decimal("1")
                 } as AreaData
             },
             {
                 id: '4',
-                label: '???',
+                label: '',
                 position: { x: 400, y: 200 },
                 class: 'light',
-                hidden: false,
+                data: {
+                    areaName: "Small Clearing",
+                    zone: Zone.FOREST,
+                    description: "A specific clearing description.",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("1")
+                } as AreaData
+            },
+            {
+                id: '5',
+                label: '',
+                position: { x: 400, y: 300 },
+                class: 'light',
+                data: {
+                    areaName: "Small Clearing",
+                    zone: Zone.FOREST,
+                    description: "A specific clearing description.",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("1")
+                } as AreaData
+            },
+            {
+                id: '6',
+                label: '',
+                position: { x: 100, y: 200 },
+                class: 'light',
+                data: {
+                    areaName: "Small Clearing",
+                    zone: Zone.FOREST,
+                    description: "A specific clearing description.",
+                    killCount: new Decimal("0"),
+                    scoutThreshold: new Decimal("1")
+                } as AreaData
             },
         ],
         edges: [
             { id: 'e1-2', source: '1', target: '2' },
             { id: 'e1-3', source: '1', target: '3' },
             { id: 'e3-4', source: '3', target: '4' },
+            { id: 'e4-5', source: '4', target: '5' },
+            { id: 'e6-5', source: '6', target: '5' },
+            { id: 'e2-6', source: '2', target: '6' },
         ],
         areaData: {
             //holds the thing to display and the list of things that can be displayed
@@ -144,7 +179,7 @@ export const useMapStore = defineStore('mapStuff', {
             return (this.getKillCount.gte(this.selectedNode.data.scoutThreshold))
         },
         hasData(): Boolean {
-            return Object.keys(this.selectedNode.data).length !== 0
+            return !!this.selectedNode.data; 
         },
     },
     actions: {
@@ -181,7 +216,29 @@ export const useMapStore = defineStore('mapStuff', {
                     let node = this.nodes.find(item => item.id === this.selectedNode.id)
       
                     if(node?.data?.killCount) {
-                      node.data.killCount = Decimal.add(node.data.killCount, amnt);
+                        console.log(node.data.killCount.toString())
+                        node.data.killCount = Decimal.add(node.data.killCount, amnt);
+                        console.log(node.data.killCount.toString())
+                        if(node.data.killCount.gte(node.data.scoutThreshold)) {
+                            //TODO: make function for this later
+                            const { getConnectedEdges, findNode } = useVueFlow();
+                            const mapEdges = getConnectedEdges(node.id);
+                            console.log(mapEdges)
+                            mapEdges.forEach(element => {
+                                let node = findNode(element.target);
+                                if(node) {
+                                    node.hidden = false;
+                                    node.data.interactable = true;
+                                    let secondEdges = getConnectedEdges(node.id);
+                                    secondEdges.forEach(innerEl => {
+                                        let innerNode = findNode(innerEl.target);
+                                        if(innerNode) {
+                                            innerNode.hidden = false;
+                                        }
+                                    })
+                                }
+                            })
+                        }
                     }
                     else {console.log("Couldn't update killcount. addKills()")}
                 }

--- a/src/stores/saveStore.ts
+++ b/src/stores/saveStore.ts
@@ -4,10 +4,13 @@ import { useUpgradeStore } from "./upgradeStore";
 import Decimal from "break_infinity.js";
 import { ref } from "vue";
 import type { SaveUpgradeArray } from "@/types/saveUpgradeArray";
+import { useMapStore } from "./mapStore";
+import type { SaveKillsArray } from "@/types/saveKillsArray";
 
 export const useSaveStore = defineStore('saveStore', () =>{
     const player = usePlayer();
     const upgrades = useUpgradeStore();
+    const mapStore = useMapStore();
 
     var saveFile = {
         currencies: {
@@ -25,7 +28,8 @@ export const useSaveStore = defineStore('saveStore', () =>{
         },
         unlocks: {
             playerUpgrades: [] as Array<SaveUpgradeArray>
-        }
+        },
+        kills: [] as Array<SaveKillsArray>
     }
 
 
@@ -48,7 +52,8 @@ export const useSaveStore = defineStore('saveStore', () =>{
             },
             unlocks: {
                 playerUpgrades: [] as Array<SaveUpgradeArray>
-            }
+            },
+            kills: [] as Array<SaveKillsArray>
         }
         saveFile.unlocks.playerUpgrades = Array.from(upgrades.soul.entries()).map((entry) => {
             return {
@@ -56,6 +61,12 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 unlocked: entry[1].show,
                 bought: entry[1].bought,
             } as SaveUpgradeArray
+        })
+        saveFile.kills = Array.from(mapStore.nodes).map((entry) => {
+            return {
+                key: entry.id,
+                kills: entry.data.killCount
+            } as SaveKillsArray
         })
         localStorage.setItem('kitsune_save', JSON.stringify(saveFile));
         console.log(saveFile)
@@ -82,8 +93,17 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 upgrades.soul.set(item.key, temp);
             }
         })
+        saveFile.kills.forEach(function(item) {
+            let temp2 = mapStore.nodes.find((element) => element.id === item.key)
+            if(temp2) {
+                temp2.data.killCount = item.kills;
+            }
+        })
+        mapStore.scouted$ = "$REFRESH$"
         console.log(saveFile)
     }
+
+    const killcountUpdate$ = "";
 
 
     return { save, load }

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -1,8 +1,11 @@
 import type { SpecialAreaId, Zone } from "@/enums/areaEnums"
+import type Decimal from "break_infinity.js"
 
 export interface AreaData {
     areaSpecialID?: SpecialAreaId
     areaName: string,
     zone: Zone,
-    description: string
+    description: string,
+    killCount: Decimal,
+    scoutThreshold: Decimal,
 }

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -8,4 +8,5 @@ export interface AreaData {
     description: string,
     killCount: Decimal,
     scoutThreshold: Decimal,
+    interactable: false
 }

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -6,7 +6,7 @@ export interface AreaData {
     areaName: string,
     zone: Zone,
     description: string,
-    killCount: Decimal,
-    scoutThreshold: Decimal,
+    killCount: number,
+    scoutThreshold: number,
     interactable: false
 }

--- a/src/types/saveKillsArray.ts
+++ b/src/types/saveKillsArray.ts
@@ -1,0 +1,4 @@
+export interface SaveKillsArray {
+    key: string,
+    kills: number,
+}


### PR DESCRIPTION
Added kill tracker and threshold to "scout" an area, which unlocks and reveals further nodes - right now it unlocks 2 out, next step will be implementing styles and locking interactable nodes to one out (with 2 out just being visible). Added functions to either unlock/reveal individual nodes or full-re-conditional-render the map on instances such as loading or resetting. Added killcount to save/load system.