### PR TITLE
Add basic resource generation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
 
         <div id="left_side_container" class="app_container">
             <div id="info_top_buttons_container">
+                <div>{{ resource }}</div>
                 <button @click="showPanel(Panels.WORLD)" v-show="combatUnlock" class="info_buttons">World</button>
                 <button @click="showPanel(Panels.SOUL)" v-show="soulUnlock" class="info_buttons">Soul</button>
                 <button @click="callCutscene('You are a fox in a forest.', [{id: 1, label:'Okay!'}, {id:2, label:'Woo!'}])"  class="info_buttons">Cutscene</button>
@@ -77,13 +78,16 @@
     import CutsceneModal from './components/CutsceneModal.vue';
     import { Panels, Tab } from './enums/panels';
     import { usePlayer } from './stores/player';
-    import { onMounted, ref } from 'vue';
+    import { onMounted, ref, watch } from 'vue';
     import { useSaveStore } from './stores/saveStore';
     import { useCombatStore } from './stores/combatStore';
+    import { useGameTick } from './stores/gameTick';
     import type { EventChoice }  from '@/types/areaEvent'
+    import { storeToRefs } from 'pinia';
     const player = usePlayer();
     const saves = useSaveStore();
     const combatStore = useCombatStore();
+    const gameTick = useGameTick();
 
     const name = "app";
 
@@ -95,6 +99,14 @@
     const cutsceneActive = ref(false);
     const cutsceneText = ref("");
     const choiceRef = ref<EventChoice[]>([]);
+    const resource = ref(0);
+
+    const { tick$ } = storeToRefs(gameTick);
+
+    watch(tick$, () => {
+        console.log('tick!');
+        resource.value = resource.value + 1;
+    });
 
 
     function showPanel (panel:Panels) {
@@ -122,6 +134,7 @@
     }
 
     onMounted(() =>{
+        gameTick.startGameTick();
         // saves.load();
     })
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@
         <div id="right_side_container" class="app_container">
             <div id="currency_section">
                 <div id="soul_counter_container">
-                    {{ player.getSoulDisplay }}<br />
+                    {{ displayDecimal(player.getSoul) }}<br />
                     <span style="font-size: 16pt;">Soul</span>
                 </div>
 <!--                 <div id="soul_bead_counters_container">
@@ -84,6 +84,7 @@
     import { useGameTick } from './stores/gameTick';
     import type { EventChoice }  from '@/types/areaEvent'
     import { storeToRefs } from 'pinia';
+    import { displayDecimal } from '@/utils/utils';
     const player = usePlayer();
     const saves = useSaveStore();
     const combatStore = useCombatStore();

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,6 @@
 
         <div id="left_side_container" class="app_container">
             <div id="info_top_buttons_container">
-                <div>{{ resource }}</div>
                 <button @click="showPanel(Panels.WORLD)" v-show="combatUnlock" class="info_buttons">World</button>
                 <button @click="showPanel(Panels.SOUL)" v-show="soulUnlock" class="info_buttons">Soul</button>
                 <button @click="callCutscene('You are a fox in a forest.', [{id: 1, label:'Okay!'}, {id:2, label:'Woo!'}])"  class="info_buttons">Cutscene</button>
@@ -78,12 +77,11 @@
     import CutsceneModal from './components/CutsceneModal.vue';
     import { Panels, Tab } from './enums/panels';
     import { usePlayer } from './stores/player';
-    import { onMounted, ref, watch } from 'vue';
+    import { onMounted, ref } from 'vue';
     import { useSaveStore } from './stores/saveStore';
     import { useCombatStore } from './stores/combatStore';
     import { useGameTick } from './stores/gameTick';
     import type { EventChoice }  from '@/types/areaEvent'
-    import { storeToRefs } from 'pinia';
     import { displayDecimal } from '@/utils/utils';
     const player = usePlayer();
     const saves = useSaveStore();
@@ -100,14 +98,6 @@
     const cutsceneActive = ref(false);
     const cutsceneText = ref("");
     const choiceRef = ref<EventChoice[]>([]);
-    const resource = ref(0);
-
-    const { tick$ } = storeToRefs(gameTick);
-
-    watch(tick$, () => {
-        console.log('tick!');
-        resource.value = resource.value + 1;
-    });
 
 
     function showPanel (panel:Panels) {

--- a/src/components/CombatPanel.vue
+++ b/src/components/CombatPanel.vue
@@ -36,11 +36,11 @@
             <div class="stats_container">
                 <div class="general_outline info_hp_bar_outline">
                     <div id="info_player_hp_bar_solid" class="hp_bar_background"></div>
-                    {{ player.getHpCurrDisplay + " / " + player.getHpMaxDisplay }}
+                    {{ displayDecimal(player.getHpCurr) + " / " + displayDecimal(player.getHpMax) }}
                 </div>
                 <div class="general_outline combat_stats">
-                    Atk: {{ player.getAtkDisplay }} <br />
-                    Def: {{ player.getDefDisplay }} <br />
+                    Atk: {{ displayDecimal(player.getAtk) }} <br />
+                    Def: {{ displayDecimal(player.getDef) }} <br />
 
                 </div>
                 <div class="combat_actions">
@@ -80,6 +80,7 @@ import { useCombatStore } from '@/stores/combatStore';
 import { ref, computed, watch } from 'vue';
 import CarouselIcon from './CarouselIcon.vue';
 import { storeToRefs } from 'pinia';
+import { displayDecimal } from '@/utils/utils'
 const player = usePlayer();
 const mapStore = useMapStore();
 const combatStore = useCombatStore();

--- a/src/stores/gameTick.ts
+++ b/src/stores/gameTick.ts
@@ -1,0 +1,19 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useGameTick = defineStore('gameTick', () => {
+    let timerId = 0;
+    const tick$ = ref(1);
+
+    function startGameTick() {
+        //Tick on every squarter of a second.
+        console.log('Game tick on!')
+        timerId = setInterval(() => tick$.value = (tick$.value === 1 ? 2 : 1), 1000 )
+    }
+
+    function stopGameTick() {
+        clearInterval(timerId)
+    }
+
+    return { tick$, startGameTick, stopGameTick }
+})

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,5 @@
+import Decimal from 'break_infinity.js'
+
+export function displayDecimal(decimal:Decimal): string {
+    return decimal.toString().replace("+","")
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.ts"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Changelog:
- Create gameTick, a simple store that has a simple game tick that ticks once per second that other things can listen to for logic. This is turned on App creation, and can be turned off with a function for future mechanics, such as a pause feature. 
- Redo player.ts to be a setup store, needed for being able to use watchers for resource generation. A few improvements were added as part of this process such as:
  - Remove all simple display functions to reduce clutter, making a helper function, `displayDecimal()` to do it instead.
  - Add a watcher  to execture a simple hp and energy regen function on every game tick.

