### PR TITLE
Improve Map Flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,7 +71,7 @@
                 <button @click="player.gameStage = GameStage.PRE_TAILS">Set gamestage intro->pre_tails</button>
                 <button @click="mapStore.callRandomEncounter(Zone.FOREST)">Fight Enemy</button>
             </div>
-            {{ "number of tails: " + player.tails }}<br />{{ "max soul: " + player.getMaxSoul }}<br />{{ "scouted: " + player.totalScouted }} <br /> {{ "kills: " + player.totalKills }}
+            {{ "number of tails: " + player.tails }}<br />{{ "max soul: " + player.getMaxSoul }}<br />{{ "areas scouted: " + player.totalScouted }} <br /> {{ "kills: " + player.totalKills }}
             <OvermapPanel />
         </div>
     </div>
@@ -91,7 +91,6 @@
     import { useCombatStore } from './stores/combatStore';
     import { GameStage } from './enums/gameStage';
     import { useGameTick } from './stores/gameTick';
-    import type { EventChoice }  from '@/types/areaEvent'
     import { displayDecimal } from '@/utils/utils';
     import { useEventStore } from './stores/eventStore'
     import { useMapStore } from './stores/mapStore';

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,10 +14,10 @@
             
             <div v-show="activePanel == Panels.WORLD">
                 <div class="tab_container">
-                    <span :class="{ selected: activeTabWorld === Tab.COMBAT, 'in-combat': combatStore.activeCombat }" @click="showTabWorld(Tab.COMBAT)" class="tab">
+                    <span :class="{ 'tab-selected': activeTabWorld === Tab.COMBAT, 'in-combat': combatStore.activeCombat }" @click="showTabWorld(Tab.COMBAT)" class="tab">
                         Combat
                     </span>
-                    <span :class="{ selected: activeTabWorld === Tab.AREA_ACTIONS }" @click="showTabWorld(Tab.AREA_ACTIONS)" class="tab">
+                    <span :class="{ 'tab-selected': activeTabWorld === Tab.AREA_ACTIONS }" @click="showTabWorld(Tab.AREA_ACTIONS)" class="tab">
                         Explore
                     </span>
                 </div>
@@ -29,7 +29,7 @@
 
             <div v-show="activePanel == Panels.SOUL">
                 <div class="tab_container">
-                    <span :class="{ selected: activeTabSoul === Tab.SOUL_UPGRADES }" @click="showTabSoul(Tab.SOUL_UPGRADES)" class="tab">
+                    <span :class="{ 'tab-selected': activeTabSoul === Tab.SOUL_UPGRADES }" @click="showTabSoul(Tab.SOUL_UPGRADES)" class="tab">
                         Soul Upgrades
                     </span>
                 </div>
@@ -171,5 +171,10 @@
     .cutscene-enter-from,
     .cutscene-leave-to {
         opacity: 0;
+    }
+
+    .tab-selected {
+        color: gold !important;
+        background:grey;
     }
 </style>

--- a/src/assets/custom-flow-theme.css
+++ b/src/assets/custom-flow-theme.css
@@ -6,10 +6,14 @@
     --vf-connection-path:  #b1b1b7;
     --vf-handle: #555;
   }
+
+  .vue-flow__edge {
+    cursor: default;
+  }
   
   .vue-flow__edge.updating .vue-flow__edge-path {
-        stroke: #777;
-      }
+    stroke: #777;
+  }
   
   .vue-flow__edge-text {
     font-size: 10px;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -328,10 +328,7 @@ button:hover {
     height: 40px;
 }
 
-.selected {
-    color: gold !important;
-    background:grey;
-}
+
 
 .tab {
     align-items: center;

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -310,9 +310,6 @@ button:hover {
     width: 100%;
     min-height: 400px;
     outline: 1px solid rgb(97, 97, 97);
-    /* overflow: hidden;
-    user-select: none;
-    cursor: all-scroll; */
 }
 
 .map_item {

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -31,9 +31,7 @@
     border-width: 3px;
     border-style: solid;
     background-color: #9ec93d;
-    color: #222;
-
-    
+    color: #222; 
   }
 
   .selected-node {

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -1,15 +1,17 @@
 <template>
-    <div class="node-boundary">
-        Hello World!
+    <div class="node-boundary" :class="{ 'selected-node': mapStore.selectedNode.id === props.data.nodeId}">
+        {{ data.areaName }}
     </div>
 </template>
 
 <script setup lang="ts">
+  import { useMapStore } from '@/stores/mapStore.js';
+  const mapStore = useMapStore();
 
   const name = "customNode";
 
   const props = defineProps({
-    id: String,
+    //id: String,
     data: {
       type: Object,
       required: true,
@@ -21,7 +23,7 @@
 </script>
 <style>
   .node-boundary {
-    border: 2px solid red;
+    border: 2px solid black;
     padding: 10px;
     border-radius: 20px;
     width: 100px;
@@ -31,6 +33,12 @@
     border-style: solid;
     background-color: #9ec93d;
     color: #222;
+
+    
+  }
+
+  .selected-node {
+    background:grey;
   }
 
 </style>

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="node-boundary">
+        Hello World!
+    </div>
+</template>
+
+<script setup lang="ts">
+
+  const name = "customNode";
+
+  const props = defineProps({
+    id: String,
+    data: {
+      type: Object,
+      required: true,
+    },
+  })
+
+  console.log(props)
+
+</script>
+<style>
+  .node-boundary {
+    border: 2px solid red;
+    padding: 10px;
+    border-radius: 20px;
+    width: 100px;
+    font-size: 16px;
+    text-align: center;
+    border-width: 3px;
+    border-style: solid;
+    background-color: #9ec93d;
+    color: #222;
+  }
+
+</style>

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="node-boundary" :class="{ 'selected-node': mapStore.selectedNode.id === props.data.nodeId}">
+    <div class="node-boundary" :class="{ 'selected-node': mapStore.selectedNode.id === props.id}">
         {{ data.areaName }}
     </div>
 </template>
@@ -10,15 +10,14 @@
 
   const name = "customNode";
 
+  //TODO: Could style based off of zone of Area in the future.
   const props = defineProps({
-    //id: String,
+    id: String,
     data: {
       type: Object,
       required: true,
     },
-  })
-
-  console.log(props)
+  }) 
 
 </script>
 <style>

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -14,8 +14,8 @@
         </div>
         <div id="vf-map">
             <VueFlow :nodes="mapStore.nodes" class="general_outline">
-                <template #node-custom ="{ data }">
-                    <CustomNode :data="data"></CustomNode>
+                <template #node-custom ="{ data, id }">
+                    <CustomNode :data="data" :id="id"></CustomNode>
                 </template>
             </VueFlow>
         </div>
@@ -96,7 +96,6 @@ const centerMap = function(node:any) {
     const NODE_WIDTH_OFFSET = -120;
     const NODE_HEIGHT_OFFSET = 150;
 
-    // WHY DOES VUE FLOW HAVE TO MAKE THIS SO HARD
     if (!!vfMap) {
         setViewport(
             {

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -38,7 +38,7 @@ const eventStore = useEventStore();
 const combatStore = useCombatStore();
 
 const { nodesDraggable, onPaneReady, elementsSelectable, onNodeClick,  findNode, findEdge, getConnectedEdges,
-     addEdges, nodes, edgesUpdatable, edgeUpdaterRadius, nodesConnectable, panOnDrag, setViewport, toObject } = useVueFlow({ id:"map"});
+     addEdges, nodes, edgesUpdatable, edgeUpdaterRadius, nodesConnectable, panOnDrag, setViewport } = useVueFlow({ id:"map"});
 
 onPaneReady((instance) => {
     nodes.value.forEach( element => {
@@ -72,6 +72,9 @@ onNodeClick((node) => {
         centerMap(chosenNode)
 
         mapStore.setTextAppend()
+        if(player.gameStage != GameStage.INTRO && !(mapStore.isSpecial === SpecialAreaId.HOME)) {
+            mapStore.callRandomEncounter(Zone.FOREST)
+        }
     }
 })
 const isConnected = function(node: any): boolean {

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -90,8 +90,8 @@ const centerMap = function(node:any) {
     // WHY DOES VUE FLOW HAVE TO MAKE THIS SO HARD
     setViewport(
         {
-            x: -node.position.x - NODE_WIDTH_OFFSET + (vfMap?.clientHeight || 0 / 2),
-            y:  -node.position.y - NODE_HEIGHT_OFFSET + (vfMap?.clientWidth || 0 / 2),
+            x: -node.position.x - NODE_WIDTH_OFFSET + (vfMap?.clientHeight / 2),
+            y:  -node.position.y - NODE_HEIGHT_OFFSET + (vfMap?.clientWidth / 2),
             zoom: 1.0,
         }, 
         { duration: 600 }

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -74,6 +74,7 @@ onNodeClick((node) => {
 
         const chosenNode = findNode(node.node.id)!;
         mapStore.selectedNode = chosenNode;
+        console.log(chosenNode);
         centerMap(chosenNode)
 
         mapStore.setTextAppend()
@@ -96,14 +97,16 @@ const centerMap = function(node:any) {
     const NODE_HEIGHT_OFFSET = 150;
 
     // WHY DOES VUE FLOW HAVE TO MAKE THIS SO HARD
-    setViewport(
-        {
-            x: -node.position.x - NODE_WIDTH_OFFSET + (vfMap?.clientHeight / 2),
-            y:  -node.position.y - NODE_HEIGHT_OFFSET + (vfMap?.clientWidth / 2),
-            zoom: 1.0,
-        }, 
-        { duration: 600 }
-    );
+    if (!!vfMap) {
+        setViewport(
+            {
+                x: -node.position.x - NODE_WIDTH_OFFSET + (vfMap?.clientHeight / 2),
+                y:  -node.position.y - NODE_HEIGHT_OFFSET + (vfMap?.clientWidth / 2),
+                zoom: 1.0,
+            }, 
+            { duration: 600 }
+        );
+    }
 }
 
 

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -74,7 +74,6 @@ onNodeClick((node) => {
 
         const chosenNode = findNode(node.node.id)!;
         mapStore.selectedNode = chosenNode;
-        console.log(chosenNode);
         centerMap(chosenNode)
 
         mapStore.setTextAppend()

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -13,13 +13,18 @@
             </div>
         </div>
         <div id="vf-map">
-            <VueFlow :nodes="mapStore.nodes" class="general_outline"></VueFlow>
+            <VueFlow :nodes="mapStore.nodes" class="general_outline">
+                <template #node-custom ="{ data }">
+                    <CustomNode :data="data"></CustomNode>
+                </template>
+            </VueFlow>
         </div>
     </div>
 </template>
 
 
 <script setup lang="ts">
+import CustomNode from './CustomNode.vue';
 import { useMapStore } from '@/stores/mapStore.js';
 import { usePlayer } from '@/stores/player';
 import { useEventStore } from '@/stores/eventStore';

--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -6,10 +6,12 @@ import { usePlayer } from '@/stores/player';
 import type { CarouselItem } from '../types/carouselItem';
 import { useMapStore } from './mapStore';
 import { GameStage } from '@/enums/gameStage';
+import { useVueFlow } from '@vue-flow/core';
 
 export const useCombatStore = defineStore('combat', () => {
     let turnTimer = 0
     let turnNumber = 0
+    const { findNode } = useVueFlow({ id:"map"});
 
     // -- State --
     const activeCombat = ref(false)
@@ -42,7 +44,7 @@ export const useCombatStore = defineStore('combat', () => {
         activeCombat.value = true;
         currentOpponent.value = enemy;
         currentHP.value = enemy.maxHP;
-        player.baseStats.currentHealth = player.baseStats.maxHealth; 
+        //player.baseStats.currentHealth = player.baseStats.maxHealth; 
 
         //initial 8-turn population of carousel
         for(turnNumber = 1; carouselArray.value.length < 8; turnNumber++) {
@@ -94,6 +96,7 @@ export const useCombatStore = defineStore('combat', () => {
         //Check for battle end.
         if(player.baseStats.currentHealth.lte(0)){
             pushToCombatLog("Defeat..")
+            mapStore.selectedNode = findNode("1")!
             endCombat();
         }
         else if(currentHP.value.lte(0)) {

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -54,17 +54,18 @@ export const useMapStore = defineStore('mapStuff', {
         nodes: [
             {
                 id: '1',
-                type: 'input',
+                type: 'custom',
                 label: 'Home',
                 position: { x: 0, y: 0 },
-                class: 'light',
+                class: 'light', 
                 data: {
                     areaSpecialID: SpecialAreaId.HOME, //Absence of this is a regular area.
                     areaName: "Home",
                     zone: Zone.FOREST,
                     description: "You can just put whatever here.",
                     killCount: 0,
-                    scoutThreshold: 0
+                    scoutThreshold: 0,
+                    nodeId: '1'
                 } as AreaData
             },
             {
@@ -78,7 +79,8 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "this be some dense foliage",
                     killCount: 0,
-                    scoutThreshold: 1
+                    scoutThreshold: 1,
+                    nodeId: '2'
                 } as AreaData
             },
             {
@@ -86,12 +88,14 @@ export const useMapStore = defineStore('mapStuff', {
                 label: '',
                 position: { x: 400, y: 100 },
                 class: 'light',
+                type: 'custom',
                 data: {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1
+                    scoutThreshold: 1,
+                    nodeId: '3'
                 } as AreaData
             },
             {
@@ -99,12 +103,14 @@ export const useMapStore = defineStore('mapStuff', {
                 label: '',
                 position: { x: 400, y: 200 },
                 class: 'light',
+                type: 'custom',
                 data: {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1
+                    scoutThreshold: 1,
+                    nodeId: '4'
                 } as AreaData
             },
             {
@@ -112,12 +118,14 @@ export const useMapStore = defineStore('mapStuff', {
                 label: '',
                 position: { x: 400, y: 300 },
                 class: 'light',
+                type: 'custom',
                 data: {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1
+                    scoutThreshold: 1,
+                    nodeId: '5'
                 } as AreaData
             },
             {
@@ -125,12 +133,14 @@ export const useMapStore = defineStore('mapStuff', {
                 label: '',
                 position: { x: 100, y: 200 },
                 class: 'light',
+                type: 'custom',
                 data: {
                     areaName: "Small Clearing",
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1
+                    scoutThreshold: 1,
+                    nodeId: '6'
                 } as AreaData
             },
         ],
@@ -228,8 +238,5 @@ export const useMapStore = defineStore('mapStuff', {
             }
         }
 
-        // sendHome() {
-        //     this.selectedNode = this.nodes[0]
-        // }
     }
 })

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -226,5 +226,9 @@ export const useMapStore = defineStore('mapStuff', {
                 else {console.log("Couldn't update killcount. addKills()")}
             }
         }
+
+        // sendHome() {
+        //     this.selectedNode = this.nodes[0]
+        // }
     }
 })

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -57,14 +57,14 @@ export const useMapStore = defineStore('mapStuff', {
                 type: 'custom',
                 label: 'Home',
                 position: { x: 0, y: 0 },
-                class: 'light', 
+                class: 'light',
                 data: {
                     areaSpecialID: SpecialAreaId.HOME, //Absence of this is a regular area.
                     areaName: "Home",
                     zone: Zone.FOREST,
                     description: "You can just put whatever here.",
                     killCount: 0,
-                    scoutThreshold: 0,
+                    scoutThreshold: 0
                 } as AreaData
             },
             {
@@ -78,7 +78,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "this be some dense foliage",
                     killCount: 0,
-                    scoutThreshold: 1,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -92,7 +92,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -106,7 +106,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -120,7 +120,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1,
+                    scoutThreshold: 1
                 } as AreaData
             },
             {
@@ -134,7 +134,7 @@ export const useMapStore = defineStore('mapStuff', {
                     zone: Zone.FOREST,
                     description: "A specific clearing description.",
                     killCount: 0,
-                    scoutThreshold: 1,
+                    scoutThreshold: 1
                 } as AreaData
             },
         ],

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -72,6 +72,7 @@ export const useMapStore = defineStore('mapStuff', {
                 label: '',
                 position: { x: 100, y: 100 },
                 class: 'light',
+                type: 'custom',
                 data: {
                     areaName: "Dense Foliage",
                     zone: Zone.FOREST,

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -65,7 +65,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "You can just put whatever here.",
                     killCount: 0,
                     scoutThreshold: 0,
-                    nodeId: '1'
                 } as AreaData
             },
             {
@@ -80,7 +79,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "this be some dense foliage",
                     killCount: 0,
                     scoutThreshold: 1,
-                    nodeId: '2'
                 } as AreaData
             },
             {
@@ -95,7 +93,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "A specific clearing description.",
                     killCount: 0,
                     scoutThreshold: 1,
-                    nodeId: '3'
                 } as AreaData
             },
             {
@@ -110,7 +107,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "A specific clearing description.",
                     killCount: 0,
                     scoutThreshold: 1,
-                    nodeId: '4'
                 } as AreaData
             },
             {
@@ -125,7 +121,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "A specific clearing description.",
                     killCount: 0,
                     scoutThreshold: 1,
-                    nodeId: '5'
                 } as AreaData
             },
             {
@@ -140,7 +135,6 @@ export const useMapStore = defineStore('mapStuff', {
                     description: "A specific clearing description.",
                     killCount: 0,
                     scoutThreshold: 1,
-                    nodeId: '6'
                 } as AreaData
             },
         ],

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -161,7 +161,7 @@ export const useMapStore = defineStore('mapStuff', {
         
     }),
     getters: {
-        isSpecial(): Boolean {
+        isSpecial(): SpecialAreaId {
             return this.selectedNode.data.areaSpecialID;
         },
         getAreaName(): string {

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -47,11 +47,11 @@ export const usePlayer = defineStore('player', () => {
 
         //Only regen at home.
         if(areaId === SpecialAreaId.HOME) {
-            //HP Regen. Set to .1/sec for now, can make a variable later.
+            //HP Regen. Set to .5/sec for now, can make a variable later.
             const stats = baseStats.value
             const energy = currencies.value
             if (stats.currentHealth.lt(stats.maxHealth)) {
-                const hpRegen = 0.1;
+                const hpRegen = 0.5;
                 if(Decimal.add(stats.currentHealth, hpRegen).gte(stats.maxHealth)) {
                     baseStats.value.currentHealth = stats.maxHealth
                 } else {

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -4,6 +4,7 @@ import { computed, ref, watch } from "vue";
 import { useMapStore } from './mapStore';
 import { useGameTick } from './gameTick';
 import { GameStage } from '@/enums/gameStage';
+import { SpecialAreaId } from '@/enums/areaEnums';
 
 export const usePlayer = defineStore('player', () => {
 
@@ -43,29 +44,35 @@ export const usePlayer = defineStore('player', () => {
     const { tick$ } = storeToRefs(gameTick);
     watch( tick$, () => {
         console.log('tick!')
-        //HP Regen. Set to .1/sec for now, can make a variable later.
-        //NOTE: maybe turn this off during combat? Can think on this later. -Malt
-        const stats = baseStats.value
-        const energy = currencies.value
-        if (stats.currentHealth.lt(stats.maxHealth)) {
-            const hpRegen = 0.1;
-            if(Decimal.add(stats.currentHealth, hpRegen).gte(stats.maxHealth)) {
-                baseStats.value.currentHealth = stats.maxHealth
-            } else {
-                // Need to figure out what rounds to decimal places in break_infinity.js
-                baseStats.value.currentHealth = Decimal.add(stats.currentHealth, hpRegen)
+        const areaId = mapStore.isSpecial
+
+        //Only regen at home.
+        if(areaId === SpecialAreaId.HOME) {
+            //HP Regen. Set to .1/sec for now, can make a variable later.
+            const stats = baseStats.value
+            const energy = currencies.value
+            if (stats.currentHealth.lt(stats.maxHealth)) {
+                const hpRegen = 0.1;
+                if(Decimal.add(stats.currentHealth, hpRegen).gte(stats.maxHealth)) {
+                    baseStats.value.currentHealth = stats.maxHealth
+                } else {
+                    // Need to figure out what rounds to decimal places in break_infinity.js
+                    baseStats.value.currentHealth = Decimal.add(stats.currentHealth, hpRegen)
+                }
+            }
+
+            //Energy Regen
+            if (energy.energy < energy.maxEnergy) {
+                const energyRegen = 0.1;
+                if((energy.energy + energyRegen) > energy.maxEnergy) {
+                    currencies.value.energy = energy.maxEnergy
+                } else {
+                    currencies.value.energy = Number((energy.energy + energyRegen).toFixed(2))
+                }
             }
         }
 
-        //Energy Regen
-        if (energy.energy < energy.maxEnergy) {
-            const energyRegen = 0.1;
-            if((energy.energy + energyRegen) > energy.maxEnergy) {
-                currencies.value.energy = energy.maxEnergy
-            } else {
-                currencies.value.energy = Number((energy.energy + energyRegen).toFixed(2))
-            }
-        }
+
     })
 
 

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -43,7 +43,6 @@ export const usePlayer = defineStore('player', () => {
     const mapStore = useMapStore();
     const { tick$ } = storeToRefs(gameTick);
     watch( tick$, () => {
-        console.log('tick!')
         const areaId = mapStore.isSpecial
 
         //Only regen at home.

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -8,5 +8,5 @@ export interface AreaData {
     description: string,
     killCount: number,
     scoutThreshold: number,
-    interactable: false,
+    interactable: false
 }

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -8,5 +8,7 @@ export interface AreaData {
     description: string,
     killCount: number,
     scoutThreshold: number,
-    interactable: false
+    interactable: false,
+    //Shouldn't have to do it this way, but it's here for now.
+    nodeId: string
 }

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -9,6 +9,4 @@ export interface AreaData {
     killCount: number,
     scoutThreshold: number,
     interactable: false,
-    //Shouldn't have to do it this way, but it's here for now.
-    nodeId: string
 }


### PR DESCRIPTION
Changelog:
- Assign an id to the Vue Flow Map, so we can access it from other places to make changes.
- Bar player from moving if they are in an existing combat.
- Center map on current node you are at, and remove dragging to make map look better.
- Make a custom node type for the map so we can better define how it looks and acts. For now, the main improvement is that we can check if the node is the one the player is currently at, then highlight it if it is.
- Change HP/energy regen to only happen while the player is currently at home space.