### PR TITLE
Complete structure for Shrine Unlock, add game flag system.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,6 @@
                 <button @click="loadToggle">{{ toggleState === "1" ? "Using save slot" : "Not using saves" }}</button>
                 <button @click="player.gameStage = GameStage.PRE_TAILS">Set gamestage intro->pre_tails</button>
                 <button @click="mapStore.callRandomEncounter(Zone.FOREST)">Fight Enemy</button>
-                <button @click="gameFlags.setFlag(FlagEnum.EXPLORE_UNLOCKED, true)">Set Explore Flag</button>
 
             </div>
             {{ "number of tails: " + player.tails }}<br />{{ "max soul: " + player.getMaxSoul }}<br />{{ "areas scouted: " + mapStore.totalScouted }} <br /> {{ "kills: " + mapStore.totalKills }}
@@ -119,7 +118,7 @@
     import InfoPanel from './components/InfoPanel.vue';
     import { Panels, Tab } from './enums/panels';
     import { usePlayer } from './stores/player';
-    import { onMounted, ref, watch } from 'vue';
+    import { onMounted, ref } from 'vue';
     import { useSaveStore } from './stores/saveStore';
     import { useCombatStore } from './stores/combatStore';
     import { GameStage } from './enums/gameStage';
@@ -145,10 +144,6 @@
     const activeTabOverworld = ref(Tab.COMBAT);
     const activeTabHome = ref(Tab.OVERVIEW);
     const activeTabSoul = ref(Tab.SOUL_UPGRADES);
-
-    watch(() => gameFlags.flagList.get(1), (flag) => {
-        console.log("Flag 1 has changed to" + flag)
-    })
     
     //TODO: This is messy and for testing, remove later
     const toggleState = ref("");
@@ -187,6 +182,7 @@
         gameTick.startGameTick();
         if(!saves.load()) {
             eventStore.callCutscene(eventStore.cutscenes.get("intro"));
+            gameFlags.initializeFlags();
         }
     })
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
         <div id="left_side_container" class="app_container">
             <div id="info_top_buttons_container">
                 <button @click="showPanel(Panels.WORLD)" class="info_buttons">World</button>
-                <button @click="showPanel(Panels.SOUL)" v-show="gameFlags.flagList.get(FlagEnum.SOUL_UNLOCKED)" class="info_buttons">Soul</button>
+                <button @click="showPanel(Panels.SOUL)" v-show="gameFlags.flagList.get(FlagEnum.SOUL_UNLOCKED)?.state" class="info_buttons">Soul</button>
             </div>
             
             <div v-show="activePanel == Panels.WORLD">
@@ -40,7 +40,7 @@
                         <span :class="{ 'tab-selected': activeTabHome === Tab.HOME_UPGRADES }" @click="showTabHome(Tab.HOME_UPGRADES)" class="tab">
                             Upgrades
                         </span>
-                        <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
+                        <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)?.state" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
                             Explore
                         </span>
                     </div>
@@ -99,7 +99,7 @@
                 <button @click="loadToggle">{{ toggleState === "1" ? "Using save slot" : "Not using saves" }}</button>
                 <button @click="player.gameStage = GameStage.PRE_TAILS">Set gamestage intro->pre_tails</button>
                 <button @click="mapStore.callRandomEncounter(Zone.FOREST)">Fight Enemy</button>
-                <button @click="gameFlags.setFlag(1, true)">Set Flag 1</button>
+                <button @click="gameFlags.setFlag(FlagEnum.EXPLORE_UNLOCKED, true)">Set Explore Flag</button>
 
             </div>
             {{ "number of tails: " + player.tails }}<br />{{ "max soul: " + player.getMaxSoul }}<br />{{ "areas scouted: " + mapStore.totalScouted }} <br /> {{ "kills: " + mapStore.totalKills }}
@@ -146,8 +146,8 @@
     const activeTabHome = ref(Tab.OVERVIEW);
     const activeTabSoul = ref(Tab.SOUL_UPGRADES);
 
-    watch(() => gameFlags.flagList.get(1), () => {
-        console.log("Flag 1 has changed!")
+    watch(() => gameFlags.flagList.get(1), (flag) => {
+        console.log("Flag 1 has changed to" + flag)
     })
     
     //TODO: This is messy and for testing, remove later

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
         <div id="left_side_container" class="app_container">
             <div id="info_top_buttons_container">
                 <button @click="showPanel(Panels.WORLD)" class="info_buttons">World</button>
-                <button @click="showPanel(Panels.SOUL)" v-show="player.soulUnlocked" class="info_buttons">Soul</button>
+                <button @click="showPanel(Panels.SOUL)" v-show="gameFlags.flagList.get(FlagEnum.SOUL_UNLOCKED)" class="info_buttons">Soul</button>
             </div>
             
             <div v-show="activePanel == Panels.WORLD">
@@ -40,10 +40,14 @@
                         <span :class="{ 'tab-selected': activeTabHome === Tab.HOME_UPGRADES }" @click="showTabHome(Tab.HOME_UPGRADES)" class="tab">
                             Upgrades
                         </span>
-                        <span v-if="player.exploreUnlocked" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
+                        <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
                             Explore
                         </span>
                     </div>
+                </div>
+
+                <div v-show="mapStore.selectedNode.data.areaSpecialID === SpecialAreaId.CLEARING">
+                    <InfoPanel v-bind:active="activeTabOverworld" />
                 </div>
 
                 <div v-show="mapStore.selectedNode.data.areaSpecialID === SpecialAreaId.HOME" class="content-container">
@@ -95,6 +99,8 @@
                 <button @click="loadToggle">{{ toggleState === "1" ? "Using save slot" : "Not using saves" }}</button>
                 <button @click="player.gameStage = GameStage.PRE_TAILS">Set gamestage intro->pre_tails</button>
                 <button @click="mapStore.callRandomEncounter(Zone.FOREST)">Fight Enemy</button>
+                <button @click="gameFlags.setFlag(1, true)">Set Flag 1</button>
+
             </div>
             {{ "number of tails: " + player.tails }}<br />{{ "max soul: " + player.getMaxSoul }}<br />{{ "areas scouted: " + mapStore.totalScouted }} <br /> {{ "kills: " + mapStore.totalKills }}
             <OvermapPanel />
@@ -113,7 +119,7 @@
     import InfoPanel from './components/InfoPanel.vue';
     import { Panels, Tab } from './enums/panels';
     import { usePlayer } from './stores/player';
-    import { onMounted, ref } from 'vue';
+    import { onMounted, ref, watch } from 'vue';
     import { useSaveStore } from './stores/saveStore';
     import { useCombatStore } from './stores/combatStore';
     import { GameStage } from './enums/gameStage';
@@ -122,6 +128,8 @@
     import { useEventStore } from './stores/eventStore'
     import { useMapStore } from './stores/mapStore';
     import { SpecialAreaId, Zone } from './enums/areaEnums';
+    import { useGameFlags } from './stores/gameFlags';
+    import { FlagEnum } from "@/enums/flagEnum"
 
     const player = usePlayer();
     const saves = useSaveStore();
@@ -129,6 +137,7 @@
     const gameTick = useGameTick();
     const eventStore = useEventStore();
     const mapStore = useMapStore();
+    const gameFlags = useGameFlags();
 
     const name = "app";
 
@@ -137,7 +146,9 @@
     const activeTabHome = ref(Tab.OVERVIEW);
     const activeTabSoul = ref(Tab.SOUL_UPGRADES);
 
-
+    watch(() => gameFlags.flagList.get(1), () => {
+        console.log("Flag 1 has changed!")
+    })
     
     //TODO: This is messy and for testing, remove later
     const toggleState = ref("");

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,6 @@
             <div id="info_top_buttons_container">
                 <button @click="showPanel(Panels.WORLD)" v-show="combatUnlock" class="info_buttons">World</button>
                 <button @click="showPanel(Panels.SOUL)" v-show="soulUnlock" class="info_buttons">Soul</button>
-                <!-- <button @click="eventStore.callCutscene(eventStore.cutscenes.get('intro'))"  class="info_buttons">Cutscene</button> -->
             </div>
             
             <div v-show="activePanel == Panels.WORLD">

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
         <div id="left_side_container" class="app_container">
             <div id="info_top_buttons_container">
                 <button @click="showPanel(Panels.WORLD)" class="info_buttons">World</button>
-                <button @click="showPanel(Panels.SOUL)" v-show="gameFlags.flagList.get(FlagEnum.SOUL_UNLOCKED)?.state" class="info_buttons">Soul</button>
+                <button @click="showPanel(Panels.SOUL)" v-show="gameFlags.flagList.get(FlagEnum.SOUL_UNLOCKED)" class="info_buttons">Soul</button>
             </div>
             
             <div v-show="activePanel == Panels.WORLD">
@@ -40,7 +40,7 @@
                         <span :class="{ 'tab-selected': activeTabHome === Tab.HOME_UPGRADES }" @click="showTabHome(Tab.HOME_UPGRADES)" class="tab">
                             Upgrades
                         </span>
-                        <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)?.state" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
+                        <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
                             Explore
                         </span>
                     </div>
@@ -182,7 +182,6 @@
         gameTick.startGameTick();
         if(!saves.load()) {
             eventStore.callCutscene(eventStore.cutscenes.get("intro"));
-            gameFlags.initializeFlags();
         }
     })
 </script>

--- a/src/components/BasePanel.vue
+++ b/src/components/BasePanel.vue
@@ -6,7 +6,8 @@
         <div v-else class="home-box">
             <div class = "base-pic"></div>
             <div class = "base-text">
-                <span>A dark, drafty cave, with little in the way of comfort. It wouldn't hurt to make this place a little bit more like a proper home...</span>
+                <span v-if="gameFlags.flagList.get(FlagEnum.SHRINE_UNLOCKED)?.state">The statue's eyes glow blue as it rests in the center of the cave.</span>
+                <span v-else>A dark, drafty cave, with little in the way of comfort. It wouldn't hurt to make this place a little bit more like a proper home...</span>
                 <PlayerHpBar style="margin-bottom: 5px; margin-top: 8px;"/>
                 <span style="color:green">Current HP Regen: {{ player.getHPRegen }}</span>
                 <span style=" color:gold">Current Energy Regen: {{ player.getEnergyRegen }}</span>
@@ -38,12 +39,15 @@ import { Tab } from '@/enums/panels';
 import { usePlayer } from '@/stores/player';
 import { useUpgradeStore } from '@/stores/upgradeStore';
 import PlayerHpBar from './playerHPBar.vue';
+import { useGameFlags } from '@/stores/gameFlags';
+import { FlagEnum } from "@/enums/flagEnum"
 
 const name = "basePanel";
 
 const mapStore = useMapStore();
 const player = usePlayer();
 const upgradeStore = useUpgradeStore();
+const gameFlags = useGameFlags();
 
 let props = defineProps({
     active: String

--- a/src/components/BasePanel.vue
+++ b/src/components/BasePanel.vue
@@ -12,7 +12,7 @@
                 <span style=" color:gold">Current Energy Regen: {{ player.getEnergyRegen }}</span>
             </div>
             <div class = "upgrades">
-                <UpgradeButton v-for="(item) in upgradeStore.home.entries()"
+                <UpgradeButton v-for="(item) in upgradeStore.getBuyableHomeUpgrades"
                     :upgrade_key="item[0]" 
                     :show="item[1].show"
                     :is_bought="item[1].bought"

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -29,9 +29,9 @@ import { useMapStore } from '@/stores/mapStore.js';
 import { usePlayer } from '@/stores/player';
 import { useEventStore } from '@/stores/eventStore';
 import { VueFlow, useVueFlow, type GraphNode } from '@vue-flow/core';
-import { SpecialAreaId, Zone } from '@/enums/areaEnums';
+import { Zone } from '@/enums/areaEnums';
 import { storeToRefs } from 'pinia';
-import { toRaw, watch } from 'vue';
+import { watch } from 'vue';
 import { useCombatStore } from '@/stores/combatStore';
 
 
@@ -59,11 +59,8 @@ onPaneReady((instance) => {
 
     edgeUpdaterRadius.value = 0;
     instance.setCenter(0, 0, {zoom: 1.0})
-    const startingNode = findNode("1")!;
-    mapStore.selectedNode = startingNode;
-
-    refreshMap();
-    centerMap(startingNode);
+    refreshMap()
+    mapStore.returnHome()    
 })
 onNodeClick((node) => {
     if (isConnected(node) && !combatStore.getActiveCombat) {
@@ -82,7 +79,7 @@ onNodeClick((node) => {
 
         
         mapStore.selectedNode = chosenNode;
-        centerMap(chosenNode)
+        mapStore.centerMap(chosenNode)
 
         mapStore.setTextAppend()
     }
@@ -93,29 +90,10 @@ const isConnected = function(node: any): boolean {
     )
 }
 
-const getConnectedNodes = function(id: string): string[] {
-    return getConnectedEdges(mapStore.selectedNode.id).map( 
-        edge => edge.target === id ? edge.source : edge.target
-    )
-}
-
 //TODO: Other issues i've noticed while fuckin around:
-//Dying doesn't set it back to home
 //If you scroll in and out you can move the map around in a weird way
 //also you cant scroll out very far? we should probably change that at least for now, so we can get a better overview of how it looks as it expands
 //also due to the spacing we may wanna make the text bigger
-const centerMap = function(node:GraphNode) {
-    //Not sure why I have to do this, but it's needed to make this work.
-    toRaw(node);
-    const nodes = getConnectedNodes(node.id);
-    nodes.push(node.id)
-    fitView({
-        nodes: nodes,
-        duration: 600
-    })
-}
-
-
 const scoutRevealNodes = function(element:GraphNode) {
     const edges = getConnectedEdges(element.id);
     edges.forEach(element => {

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -69,14 +69,16 @@ onNodeClick((node) => {
     if (isConnected(node) && !combatStore.getActiveCombat) {
         const chosenNode = findNode(node.node.id)!;
 
+        //TODO: Make this check use gameFlags
         if(player.firstMove) {
             player.firstMove = false;
             combatStore.startCombat(mapStore.enemyList[0]);
             eventStore.callCutscene(eventStore.cutscenes.get("firstMove"));
-        }
-        else if(!(chosenNode?.data?.areaSpecialID === SpecialAreaId.HOME)) {
+        } else if(!!chosenNode?.data?.customFunc) {
+            chosenNode.data.customFunc();
+        } else if(!(!!chosenNode?.data?.areaSpecialID)) {
             mapStore.callRandomEncounter(Zone.FOREST)
-        }
+        } 
 
         
         mapStore.selectedNode = chosenNode;

--- a/src/components/SoulUpgradePanel.vue
+++ b/src/components/SoulUpgradePanel.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-show="active === 'soulUpgrades'">
-        <UpgradeButton v-for="(item) in upgrade.soul.entries()"
-        :upgrade_key="item[0]" 
+        <UpgradeButton v-for="(item) in upgrade.getBuyableSoulUpgrades"
+            :upgrade_key="item[0]" 
             :show="item[1].show"
             :is_bought="item[1].bought"
             :upgrade_category="item[1].category"

--- a/src/enums/ResourceEnum.ts
+++ b/src/enums/ResourceEnum.ts
@@ -1,0 +1,4 @@
+export enum ResourceEnum {
+    FIBER = "fiber",
+    STONE = "stone"
+}

--- a/src/enums/flagEnum.ts
+++ b/src/enums/flagEnum.ts
@@ -1,5 +1,6 @@
 export enum FlagEnum {
     EXPLORE_UNLOCKED = 1,
+    STATUE_OBTAINED,
     SHRINE_UNLOCKED,
     SOUL_UNLOCKED
 }

--- a/src/enums/flagEnum.ts
+++ b/src/enums/flagEnum.ts
@@ -1,0 +1,5 @@
+export enum FlagEnum {
+    EXPLORE_UNLOCKED = 1,
+    SHRINE_UNLOCKED,
+    SOUL_UNLOCKED
+}

--- a/src/enums/flagEnum.ts
+++ b/src/enums/flagEnum.ts
@@ -1,6 +1,6 @@
 export enum FlagEnum {
-    EXPLORE_UNLOCKED = 1,
-    STATUE_OBTAINED,
-    SHRINE_UNLOCKED,
-    SOUL_UNLOCKED
+    EXPLORE_UNLOCKED = 1, //Have you encountered the stone statue yet?
+    STATUE_OBTAINED, //Have you obtained the stone statue?
+    SHRINE_UNLOCKED, // Have you returned the statue home?
+    SOUL_UNLOCKED //Have you completed the soul unlock intro?
 }

--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -94,7 +94,7 @@ export const useCombatStore = defineStore('combat', () => {
         //Check for battle end.
         if(player.getHpCurr.lte(0)){
             pushToCombatLog("Defeat..")
-            mapStore.selectedNode = findNode("1")!
+            mapStore.returnHome()
             endCombat();
         }
         else if(currentHP.value.lte(0)) {

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -1,16 +1,17 @@
-import type { EventChoice } from "@/types/areaEvent";
 import { defineStore } from "pinia";
-import { ref, watch, watchEffect } from "vue";
+import { ref, watch } from "vue";
 import { useCombatStore } from "./combatStore";
 import type { Cutscene } from "@/types/cutscene";
 import { useMapStore } from "./mapStore";
 import { usePlayer } from "./player";
 import { GameStage } from "@/enums/gameStage";
+import { useGameFlags } from "./gameFlags";
 
 export const useEventStore = defineStore('eventstore', () => {
     const combatStore = useCombatStore();
     const mapStore = useMapStore();
     const player = usePlayer();
+    const gameFlags = useGameFlags();
 
     const activeScene = ref<Cutscene>();
     const sceneDesc = ref("");
@@ -144,6 +145,9 @@ export const useEventStore = defineStore('eventstore', () => {
                     label: "Neat!"
                 }
             ],
+            cutsceneCallback: function() {
+                gameFlags.setShrine1(true);
+            }
         }],
     ])
 

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -141,15 +141,9 @@ export const useEventStore = defineStore('eventstore', () => {
             choices: [
                 {
                     id: 1,
-                    label: "Continue"
+                    label: "Neat!"
                 }
             ],
-            cutsceneCallback: function(choice) {
-                player.gameStage = GameStage.PRE_TAILS;
-                player.addFood(player.getFood.times(-1)); //Food aint stored here, it becomes an actual resource again later but not yet baybee
-                activeScene.value = undefined;
-            },
-            chain: true,
         }],
     ])
 

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -156,8 +156,11 @@ export const useEventStore = defineStore('eventstore', () => {
                     label: "Continue"
                 }
             ],
-            cutsceneCallback: function() {}
+            cutsceneCallback: function() {
+                mapStore.returnHome();
+            }
         }],
+        //TODO: This doesn't fire properly off of a chain for some reason. I could mess with the chain infrastructure right now to fix this, but I'll leav it as is.
         ["idolReturned", {
             title: "",
             description: "After a long journey, you finally bring the stone statue home, dragging it into the center of the cave. Looking at it, a feeling of tranquility washes over you.",

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -136,18 +136,38 @@ export const useEventStore = defineStore('eventstore', () => {
             },
             chain: true,
         }],
-        ["idolGet", {
+        ["idolFind", {
             title: "",
-            description: "You find a strange idol",
+            description: "You find a large stone idol half buried in the ground. You are drawn to bring it back home with you, but it's too big to carry in your mouth...<br /> <br />[New options are available at Home.]",
             choices: [
                 {
                     id: 1,
-                    label: "Neat!"
+                    label: "Continue"
                 }
             ],
-            cutsceneCallback: function() {
-                gameFlags.setFlag(1, true);
-            }
+            cutsceneCallback: function() {}
+        }],
+        ["idolGet", {
+            title: "",
+            description: "You awkwardly tie the rope to the statue and begin pulling it back...",
+            choices: [
+                {
+                    id: 1,
+                    label: "Continue"
+                }
+            ],
+            cutsceneCallback: function() {}
+        }],
+        ["idolReturned", {
+            title: "",
+            description: "After a long journey, you finally bring the stone statue home, dragging it into the center of the cave. Looking at it, a feeling of tranquility washes over you.",
+            choices: [
+                {
+                    id: 1,
+                    label: "Continue"
+                }
+            ],
+            cutsceneCallback: function() {}
         }],
     ])
 

--- a/src/stores/eventStore.ts
+++ b/src/stores/eventStore.ts
@@ -146,7 +146,7 @@ export const useEventStore = defineStore('eventstore', () => {
                 }
             ],
             cutsceneCallback: function() {
-                gameFlags.setShrine1(true);
+                gameFlags.setFlag(1, true);
             }
         }],
     ])

--- a/src/stores/gameFlags.ts
+++ b/src/stores/gameFlags.ts
@@ -1,0 +1,32 @@
+import type { GameFlag } from "@/types/gameFlag"
+import { defineStore } from "pinia"
+import { computed, ref } from "vue"
+
+export const useGameFlags = defineStore('gameFlags', () => {
+  
+	// --- State ---
+
+	//TODO: I've wussed out on making a Map of GameFlags due to the thorny issues around making a Map reactive on it's entries
+	//and not it's keys not coming to me right now. Going to just make individual gameFlag variables for now.
+	//const gameFlags = ref<Map<string, GameFlag>>()
+	const shrine1 = ref<GameFlag>({description: "Have you encountered the stone statue yet? ", flagOn: false})
+	const shrine2 = ref<GameFlag>({description: "Have you returned the statue back home? ", flagOn: false})
+
+	// --- Getters/Computeds ---
+	const getShrine1 = computed(() => shrine1.value.flagOn)
+	const getShrine2 = computed(() => shrine2.value.flagOn)
+
+	//Actions
+    function setShrine1(state: boolean): void {shrine1.value.flagOn = state}
+	function setShrine2(state: boolean): void {shrine2.value.flagOn = state}
+
+
+	return {
+		//State
+		shrine1, shrine2,
+        //Computed
+        getShrine1, getShrine2,
+		//Actions
+		setShrine1, setShrine2
+	}
+})

--- a/src/stores/gameFlags.ts
+++ b/src/stores/gameFlags.ts
@@ -6,27 +6,7 @@ import { ref } from "vue"
 export const useGameFlags = defineStore('gameFlags', () => {
   
 	// --- State ---
-    //This should be an empty map once we get this actually working fully.
-    //const flagList = ref<Map<string, GameFlag>>();
-
-    const flagList = ref<Map<FlagEnum, GameFlag>>(new Map<FlagEnum, GameFlag>([
-        [FlagEnum.EXPLORE_UNLOCKED, {
-            description: "Have you encountered the stone statue yet?",
-            state:false
-        }],
-        [FlagEnum.STATUE_OBTAINED, {
-            description: "Have you obtained the stone statue?",
-            state:false
-        }],
-        [FlagEnum.SHRINE_UNLOCKED, {
-            description: "Have you returned the statue home?",
-            state:false
-        }],
-        [FlagEnum.SOUL_UNLOCKED, {
-            description: "Have you unlocked soul through the intro?",
-            state:true
-        }],
-    ]))
+    const flagList = ref<Map<FlagEnum, GameFlag>>(new Map<FlagEnum, GameFlag>([]))
 
 	//Actions
     //Returns true if operation was successsful, false otherwise.
@@ -39,14 +19,31 @@ export const useGameFlags = defineStore('gameFlags', () => {
         return false;
     }
     //do this on a new file.
-    // function initializeFlags(): void {
+    function initializeFlags(): void {
+        flagList.value = new Map<FlagEnum, GameFlag>([
+            [FlagEnum.EXPLORE_UNLOCKED, {
+                description: "Have you encountered the stone statue yet?",
+                state:false
+            }],
+            [FlagEnum.STATUE_OBTAINED, {
+                description: "Have you obtained the stone statue?",
+                state:false
+            }],
+            [FlagEnum.SHRINE_UNLOCKED, {
+                description: "Have you returned the statue home?",
+                state:false
+            }],
+            [FlagEnum.SOUL_UNLOCKED, {
+                description: "Have you unlocked soul through the intro?",
+                state:false
+            }],
+        ])
+    }
 
-    // }
-
-    // function reInitFlags: can do this on load to add new flags in.
+    // TODO function reInitFlags: can do this on load to add new flags in. Add this later.
 
 
 	return {
-		flagList, setFlag
+		flagList, setFlag, initializeFlags
 	}
 })

--- a/src/stores/gameFlags.ts
+++ b/src/stores/gameFlags.ts
@@ -14,6 +14,10 @@ export const useGameFlags = defineStore('gameFlags', () => {
             description: "Have you encountered the stone statue yet?",
             state:false
         }],
+        [FlagEnum.STATUE_OBTAINED, {
+            description: "Have you obtained the stone statue?",
+            state:false
+        }],
         [FlagEnum.SHRINE_UNLOCKED, {
             description: "Have you returned the statue home?",
             state:false

--- a/src/stores/gameFlags.ts
+++ b/src/stores/gameFlags.ts
@@ -1,32 +1,48 @@
+import { FlagEnum } from "@/enums/flagEnum"
 import type { GameFlag } from "@/types/gameFlag"
 import { defineStore } from "pinia"
-import { computed, ref } from "vue"
+import { ref } from "vue"
 
 export const useGameFlags = defineStore('gameFlags', () => {
   
 	// --- State ---
+    //This should be an empty map once we get this actually working fully.
+    //const flagList = ref<Map<string, GameFlag>>();
 
-	//TODO: I've wussed out on making a Map of GameFlags due to the thorny issues around making a Map reactive on it's entries
-	//and not it's keys not coming to me right now. Going to just make individual gameFlag variables for now.
-	//const gameFlags = ref<Map<string, GameFlag>>()
-	const shrine1 = ref<GameFlag>({description: "Have you encountered the stone statue yet? ", flagOn: false})
-	const shrine2 = ref<GameFlag>({description: "Have you returned the statue back home? ", flagOn: false})
-
-	// --- Getters/Computeds ---
-	const getShrine1 = computed(() => shrine1.value.flagOn)
-	const getShrine2 = computed(() => shrine2.value.flagOn)
+    const flagList = ref<Map<FlagEnum, GameFlag>>(new Map<FlagEnum, GameFlag>([
+        [FlagEnum.EXPLORE_UNLOCKED, {
+            description: "Have you encountered the stone statue yet?",
+            state:false
+        }],
+        [FlagEnum.SHRINE_UNLOCKED, {
+            description: "Have you returned the statue home?",
+            state:false
+        }],
+        [FlagEnum.SOUL_UNLOCKED, {
+            description: "Have you unlocked soul through the intro?",
+            state:true
+        }],
+    ]))
 
 	//Actions
-    function setShrine1(state: boolean): void {shrine1.value.flagOn = state}
-	function setShrine2(state: boolean): void {shrine2.value.flagOn = state}
+    //Returns true if operation was successsful, false otherwise.
+    function setFlag(x: number, newState:boolean): boolean { 
+        const mapValue = flagList.value.get(x)
+        if (!!mapValue) {
+            flagList.value.set(x, {description: mapValue.description, state: newState})
+            return true;
+        }
+        return false;
+    }
+    //do this on a new file.
+    // function initializeFlags(): void {
+
+    // }
+
+    // function reInitFlags: can do this on load to add new flags in.
 
 
 	return {
-		//State
-		shrine1, shrine2,
-        //Computed
-        getShrine1, getShrine2,
-		//Actions
-		setShrine1, setShrine2
+		flagList, setFlag
 	}
 })

--- a/src/stores/gameFlags.ts
+++ b/src/stores/gameFlags.ts
@@ -1,49 +1,18 @@
 import { FlagEnum } from "@/enums/flagEnum"
-import type { GameFlag } from "@/types/gameFlag"
 import { defineStore } from "pinia"
 import { ref } from "vue"
 
 export const useGameFlags = defineStore('gameFlags', () => {
   
 	// --- State ---
-    const flagList = ref<Map<FlagEnum, GameFlag>>(new Map<FlagEnum, GameFlag>([]))
+    const flagList = ref<Map<FlagEnum, boolean>>(new Map<FlagEnum, boolean>([]))
 
 	//Actions
-    //Returns true if operation was successsful, false otherwise.
-    function setFlag(x: number, newState:boolean): boolean { 
-        const mapValue = flagList.value.get(x)
-        if (!!mapValue) {
-            flagList.value.set(x, {description: mapValue.description, state: newState})
-            return true;
-        }
-        return false;
+    function setFlag(x: number, newState:boolean): void { 
+        flagList.value.set(x, newState)
     }
-    //do this on a new file.
-    function initializeFlags(): void {
-        flagList.value = new Map<FlagEnum, GameFlag>([
-            [FlagEnum.EXPLORE_UNLOCKED, {
-                description: "Have you encountered the stone statue yet?",
-                state:false
-            }],
-            [FlagEnum.STATUE_OBTAINED, {
-                description: "Have you obtained the stone statue?",
-                state:false
-            }],
-            [FlagEnum.SHRINE_UNLOCKED, {
-                description: "Have you returned the statue home?",
-                state:false
-            }],
-            [FlagEnum.SOUL_UNLOCKED, {
-                description: "Have you unlocked soul through the intro?",
-                state:false
-            }],
-        ])
-    }
-
-    // TODO function reInitFlags: can do this on load to add new flags in. Add this later.
-
 
 	return {
-		flagList, setFlag, initializeFlags
+		flagList, setFlag, 
 	}
 })

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -9,6 +9,7 @@ import { computed, ref } from 'vue'
 import { useGameFlags } from './gameFlags'
 import { useEventStore } from './eventStore'
 import { FlagEnum } from '@/enums/flagEnum'
+import { useUpgradeStore } from './upgradeStore'
 
 /* LEAVE THIS HERE >:(
 name: "",
@@ -25,6 +26,7 @@ export const useMapStore = defineStore('mapStuff', () => {
 
     const gameFlags = useGameFlags();
     const eventStore = useEventStore();
+    const upgradeStore = useUpgradeStore();
 
     // -- State --
 
@@ -235,9 +237,15 @@ export const useMapStore = defineStore('mapStuff', () => {
         data: {
             areaSpecialID: SpecialAreaId.CLEARING, 
             customFunc: function() {
-                if(!gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)){
+                if(!gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)?.state){
                     eventStore.callCutscene(eventStore.cutscenes.get("idolGet"))
                     gameFlags.setFlag(FlagEnum.EXPLORE_UNLOCKED, true)
+                    //TODO: Could probably make helper functions in upgradeStore for this.
+                    const ropeUpgrade = upgradeStore.home.get(4)
+                    if (!!ropeUpgrade) {
+                        ropeUpgrade.show = true
+                        upgradeStore.home.set(4, ropeUpgrade)
+                    }
                 }
             },
             areaName: "Strange Clearing",

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -67,11 +67,21 @@ export const useMapStore = defineStore('mapStuff', () => {
         class: 'light',
         data: {
             areaSpecialID: SpecialAreaId.HOME, //Absence of this is a regular area.
+            customFunc: function() {
+                //Check for progress in the Unlock Shrine storyline.
+
+                if(!gameFlags.flagList.get(FlagEnum.SHRINE_UNLOCKED)?.state && 
+                gameFlags.flagList.get(FlagEnum.STATUE_OBTAINED)?.state){
+                    eventStore.callCutscene(eventStore.cutscenes.get("idolReturned"))
+                    gameFlags.setFlag(FlagEnum.SHRINE_UNLOCKED, true)
+                } 
+            },
             areaName: "Home",
             zone: Zone.FOREST,
             description: "You can just put whatever here.",
             killCount: 0,
-            scoutThreshold: 0
+            scoutThreshold: 0,
+            interactable: false,
         } as AreaData
     },
     {
@@ -237,13 +247,24 @@ export const useMapStore = defineStore('mapStuff', () => {
         data: {
             areaSpecialID: SpecialAreaId.CLEARING, 
             customFunc: function() {
+                //Check for progress in the Unlock Shrine storyline.
+
                 if(!gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)?.state){
-                    eventStore.callCutscene(eventStore.cutscenes.get("idolGet"))
+                    eventStore.callCutscene(eventStore.cutscenes.get("idolFind"))
                     gameFlags.setFlag(FlagEnum.EXPLORE_UNLOCKED, true)
                     //TODO: Could probably make helper functions in upgradeStore for this.
                     const ropeUpgrade = upgradeStore.home.get(4)
                     if (!!ropeUpgrade) {
                         ropeUpgrade.show = true
+                        upgradeStore.home.set(4, ropeUpgrade)
+                    }
+                } else if (!gameFlags.flagList.get(FlagEnum.STATUE_OBTAINED)?.state && upgradeStore.home.get(4)?.bought) {
+                    eventStore.callCutscene(eventStore.cutscenes.get("idolGet"))
+                    gameFlags.setFlag(FlagEnum.STATUE_OBTAINED, true)
+                    //TODO: Could probably make helper functions in upgradeStore for this.
+                    const ropeUpgrade = upgradeStore.home.get(4)
+                    if (!!ropeUpgrade) {
+                        ropeUpgrade.show = false
                         upgradeStore.home.set(4, ropeUpgrade)
                     }
                 }

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -8,6 +8,7 @@ import { useCombatStore } from '@/stores/combatStore';
 import { computed, ref } from 'vue'
 import { useGameFlags } from './gameFlags'
 import { useEventStore } from './eventStore'
+import { FlagEnum } from '@/enums/flagEnum'
 
 /* LEAVE THIS HERE >:(
 name: "",
@@ -232,10 +233,11 @@ export const useMapStore = defineStore('mapStuff', () => {
         class: 'light',
         type: 'custom',
         data: {
-            areaSpecialID: SpecialAreaId.SHRINE, 
+            areaSpecialID: SpecialAreaId.CLEARING, 
             customFunc: function() {
-                if(!gameFlags.getShrine1){
+                if(!gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)){
                     eventStore.callCutscene(eventStore.cutscenes.get("idolGet"))
+                    gameFlags.setFlag(FlagEnum.EXPLORE_UNLOCKED, true)
                 }
             },
             areaName: "Strange Clearing",

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -6,6 +6,8 @@ import type { AreaData } from '@/types/areaData'
 import { SpecialAreaId, Zone } from '@/enums/areaEnums'
 import { useCombatStore } from '@/stores/combatStore';
 import { computed, ref } from 'vue'
+import { useGameFlags } from './gameFlags'
+import { useEventStore } from './eventStore'
 
 /* LEAVE THIS HERE >:(
 name: "",
@@ -19,6 +21,9 @@ soulKill: new Decimal(""),
 
 
 export const useMapStore = defineStore('mapStuff', () => {
+
+    const gameFlags = useGameFlags();
+    const eventStore = useEventStore();
 
     // -- State --
 
@@ -227,12 +232,18 @@ export const useMapStore = defineStore('mapStuff', () => {
         class: 'light',
         type: 'custom',
         data: {
-            //Will be special
+            areaSpecialID: SpecialAreaId.SHRINE, 
+            customFunc: function() {
+                if(!gameFlags.getShrine1){
+                    eventStore.callCutscene(eventStore.cutscenes.get("idolGet"))
+                }
+            },
             areaName: "Strange Clearing",
             zone: Zone.FOREST,
             description: "i imagine special locations are gonna just have fully different formatting so this doesnt matter lol",
             killCount: 0,
-            scoutThreshold: 1
+            scoutThreshold: 1,
+            interactable: false,
         } as AreaData
     }]);
 

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -9,6 +9,7 @@ import { SpecialAreaId } from '@/enums/areaEnums';
 export const usePlayer = defineStore('player', () => {
 
     // -- Game states --
+    //TODO: Some of these can be changes to GameFlags.
     const loaded = ref(false);
     const firstMove = ref(true);
     const gameStage = ref(GameStage.INTRO);

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -10,13 +10,12 @@ export const usePlayer = defineStore('player', () => {
 
     // -- Game states --
     //TODO: Some of these can be changes to GameFlags.
+    //TODO: Save flags, as well
     const loaded = ref(false);
     const firstMove = ref(true);
     const gameStage = ref(GameStage.INTRO);
     const furthestStage = ref(GameStage.INTRO);
     const deniedSoul = ref(false);
-    const exploreUnlocked = ref(false);
-    const soulUnlocked = ref(false);
 
 
 
@@ -200,7 +199,7 @@ export const usePlayer = defineStore('player', () => {
 
     return {
         //Stats
-        currencies, name, tails, playerStats, gameStage, furthestStage, loaded, firstMove, deniedSoul, exploreUnlocked, soulUnlocked,
+        currencies, name, tails, playerStats, gameStage, furthestStage, loaded, firstMove, deniedSoul,
         //Computeds
         getAtk, getDef, getHpCurr, getHpMax, getSpd, getSoul, getMaxSoul, getEnergyDisplay, playerHpRatio, getFood,
         getHPRegen, getEnergyRegen,

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -5,6 +5,7 @@ import { useMapStore } from './mapStore';
 import { useGameTick } from './gameTick';
 import { GameStage } from '@/enums/gameStage';
 import { SpecialAreaId } from '@/enums/areaEnums';
+import { ResourceEnum } from '@/enums/ResourceEnum';
 
 export const usePlayer = defineStore('player', () => {
 
@@ -25,8 +26,13 @@ export const usePlayer = defineStore('player', () => {
         maxSoul: new Decimal("10"),
         food: new Decimal("0"),
         energy: 40,
-        maxEnergy: 100
+        maxEnergy: 100,
     })
+
+    const resources = ref<Map<ResourceEnum, number>>(new Map<ResourceEnum, number>([
+        [ResourceEnum.FIBER, 0],
+        [ResourceEnum.STONE, 0],
+    ]))
 
     const name = ref("Fox")
     const tails = ref(1)
@@ -199,7 +205,7 @@ export const usePlayer = defineStore('player', () => {
 
     return {
         //Stats
-        currencies, name, tails, playerStats, gameStage, furthestStage, loaded, firstMove, deniedSoul,
+        currencies, name, tails, playerStats, gameStage, furthestStage, loaded, firstMove, deniedSoul, resources,
         //Computeds
         getAtk, getDef, getHpCurr, getHpMax, getSpd, getSoul, getMaxSoul, getEnergyDisplay, playerHpRatio, getFood,
         getHPRegen, getEnergyRegen,

--- a/src/stores/saveStore.ts
+++ b/src/stores/saveStore.ts
@@ -5,7 +5,6 @@ import Decimal from "break_infinity.js";
 import { ref } from "vue";
 import type { SaveUpgradeArray, SaveKillsArray, SavedGameFlags } from "@/types/saveArrays";
 import { useMapStore } from "./mapStore";
-import type { GameFlag } from "@/types/gameFlag";
 import { useGameFlags } from "./gameFlags";
 import type { FlagEnum } from "@/enums/flagEnum";
 
@@ -90,8 +89,7 @@ export const useSaveStore = defineStore('saveStore', () =>{
         saveFile.gameFlags = Array.from(gameFlags.flagList).map((entry) => {
             return {
                 key: entry[0],
-                description: entry[1].description,
-                state: entry[1].state
+                state: entry[1]
             } as SavedGameFlags
         })
         localStorage.setItem('kitsune_save', JSON.stringify(saveFile));
@@ -135,12 +133,9 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 temp2.data.killCount = item.kills;
             }
         })
-        const gameFlagsMap = new Map<FlagEnum, GameFlag>([])
+        const gameFlagsMap = new Map<FlagEnum, boolean>([])
         saveFile.gameFlags.forEach(function(item) {
-            gameFlagsMap.set(item.key, {
-                description: item.description,
-                state: item.state
-            })
+            gameFlagsMap.set(item.key, item.state)
         })
         gameFlags.flagList = gameFlagsMap
         mapStore.scouted$ = "$REFRESH$"

--- a/src/stores/saveStore.ts
+++ b/src/stores/saveStore.ts
@@ -18,7 +18,6 @@ export const useSaveStore = defineStore('saveStore', () =>{
         furthestStage: player.furthestStage,
         firstMove: player.firstMove,
         deniedSoul: player.deniedSoul,
-        exploreUnlocked: player.exploreUnlocked,
 
 
         currencies: {
@@ -50,8 +49,6 @@ export const useSaveStore = defineStore('saveStore', () =>{
             furthestStage: player.furthestStage,
             firstMove: player.firstMove,
             deniedSoul: player.deniedSoul,
-            exploreUnlocked: player.exploreUnlocked,
-
 
             currencies: {
                 soul: player.currencies.soul,
@@ -100,7 +97,6 @@ export const useSaveStore = defineStore('saveStore', () =>{
         player.furthestStage = saveFile.furthestStage;
         player.firstMove = saveFile.firstMove;
         player.deniedSoul = saveFile.deniedSoul;
-        player.exploreUnlocked = saveFile.exploreUnlocked;
 
         player.currencies.soul = new Decimal(saveFile.currencies.soul);
         player.currencies.maxSoul = new Decimal(saveFile.currencies.maxSoul);

--- a/src/stores/saveStore.ts
+++ b/src/stores/saveStore.ts
@@ -3,14 +3,17 @@ import { usePlayer } from "./player";
 import { useUpgradeStore } from "./upgradeStore";
 import Decimal from "break_infinity.js";
 import { ref } from "vue";
-import type { SaveUpgradeArray } from "@/types/saveUpgradeArray";
+import type { SaveUpgradeArray, SaveKillsArray, SavedGameFlags } from "@/types/saveArrays";
 import { useMapStore } from "./mapStore";
-import type { SaveKillsArray } from "@/types/saveKillsArray";
+import type { GameFlag } from "@/types/gameFlag";
+import { useGameFlags } from "./gameFlags";
+import type { FlagEnum } from "@/enums/flagEnum";
 
 export const useSaveStore = defineStore('saveStore', () =>{
     const player = usePlayer();
     const upgrades = useUpgradeStore();
     const mapStore = useMapStore();
+    const gameFlags = useGameFlags();
 
     var saveFile = {
         //TODO: gamestage stuff
@@ -36,7 +39,8 @@ export const useSaveStore = defineStore('saveStore', () =>{
         unlocks: {
             playerUpgrades: [] as Array<SaveUpgradeArray>
         },
-        kills: [] as Array<SaveKillsArray>
+        kills: [] as Array<SaveKillsArray>,
+        gameFlags: [] as Array<SavedGameFlags>
     }
 
 
@@ -66,10 +70,11 @@ export const useSaveStore = defineStore('saveStore', () =>{
             unlocks: {
                 playerUpgrades: [] as Array<SaveUpgradeArray>
             },
-            kills: [] as Array<SaveKillsArray>
+            kills: [] as Array<SaveKillsArray>,
+            gameFlags: [] as Array<SavedGameFlags>
         }
-        //TODO: this only saves upgrades in the soul category
-        saveFile.unlocks.playerUpgrades = Array.from(upgrades.soul.entries()).map((entry) => {
+        //TODO: this only saves upgrades in the home category
+        saveFile.unlocks.playerUpgrades = Array.from(upgrades.home.entries()).map((entry) => {
             return {
                 key: entry[0],
                 unlocked: entry[1].show,
@@ -81,6 +86,13 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 key: entry.id,
                 kills: entry.data.killCount
             } as SaveKillsArray
+        })
+        saveFile.gameFlags = Array.from(gameFlags.flagList).map((entry) => {
+            return {
+                key: entry[0],
+                description: entry[1].description,
+                state: entry[1].state
+            } as SavedGameFlags
         })
         localStorage.setItem('kitsune_save', JSON.stringify(saveFile));
         console.log(saveFile)
@@ -110,11 +122,11 @@ export const useSaveStore = defineStore('saveStore', () =>{
             spd: saveFile.playerStats.spd
         };
         saveFile.unlocks.playerUpgrades.forEach(function(item) {
-            let temp = upgrades.soul.get(item.key);
+            let temp = upgrades.home.get(item.key);
             if(temp) {
                 temp.show = item.unlocked;
                 temp.bought = item.bought;
-                upgrades.soul.set(item.key, temp);
+                upgrades.home.set(item.key, temp);
             }
         })
         saveFile.kills.forEach(function(item) {
@@ -123,6 +135,14 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 temp2.data.killCount = item.kills;
             }
         })
+        const gameFlagsMap = new Map<FlagEnum, GameFlag>([])
+        saveFile.gameFlags.forEach(function(item) {
+            gameFlagsMap.set(item.key, {
+                description: item.description,
+                state: item.state
+            })
+        })
+        gameFlags.flagList = gameFlagsMap
         mapStore.scouted$ = "$REFRESH$"
         console.log(saveFile)
         

--- a/src/stores/upgradeStore.ts
+++ b/src/stores/upgradeStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import Decimal from 'break_infinity.js'
 import { usePlayer } from './player'
 import { type Upgrade, UpgradeCategory } from '@/types/upgrade'
+import { ResourceEnum } from '@/enums/ResourceEnum'
 
 export const useUpgradeStore = defineStore('upgradeStore', {
     state: () => ({
@@ -110,7 +111,39 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 }
 
             }],
+            [4,{
+                show: false,
+                bought: false,
+                category: UpgradeCategory.HOME,
+                title: "Makeshift Rope",
+                flavor: "Find a long enough vine to wrap around the strange statue so you can drag it home.",
+                effectDescription: "Take this back to the Strange Clearing.",
+                costDescription:"Costs 5 Fiber.",
+                costFunc: (buyCheck: boolean) => {
+                    const player = usePlayer();
+                    const fiber = player.resources.get(ResourceEnum.FIBER) || 0
+                    if (fiber < 5) {
+                        return false;
+                    }
+
+                    if(!buyCheck) {
+                        player.resources.set(ResourceEnum.FIBER, fiber-5) 
+                    }
+                    return true;
+                },
+                //We can check to see if this is bought at the Clearing.
+                effect: function() {}
+
+            }],
         ])
 
     }),
+    getters: {
+        getBuyableHomeUpgrades: (state) => {
+            return Array.from(state.home.entries()).filter( upgrade => upgrade[1].show === true)
+        },
+        getBuyableSoulUpgrades: (state) => {
+            return Array.from(state.soul.entries()).filter( upgrade => upgrade[1].show === true)
+        }
+    }
 })

--- a/src/stores/upgradeStore.ts
+++ b/src/stores/upgradeStore.ts
@@ -118,22 +118,33 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 title: "Makeshift Rope",
                 flavor: "Find a long enough vine to wrap around the strange statue so you can drag it home.",
                 effectDescription: "Take this back to the Strange Clearing.",
-                costDescription:"Costs 5 Fiber.",
+                costDescription:"Costs 5 Fiber. (For now, costs 10 soul instead.)",
+                // costFunc: (buyCheck: boolean) => {
+                //     const player = usePlayer();
+                //     const fiber = player.resources.get(ResourceEnum.FIBER) || 0
+                //     if (fiber < 5) {
+                //         return false;
+                //     }
+
+                //     if(!buyCheck) {
+                //         player.resources.set(ResourceEnum.FIBER, fiber-5) 
+                //     }
+                //     return true;
+                // },
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
-                    const fiber = player.resources.get(ResourceEnum.FIBER) || 0
-                    if (fiber < 5) {
-                        return false;
+                    const canBuy = player.enoughSoul(10);
+                    if (buyCheck) {
+                        return canBuy;
                     }
 
-                    if(!buyCheck) {
-                        player.resources.set(ResourceEnum.FIBER, fiber-5) 
+                    if(canBuy) {
+                        player.subtractSoul(10);  
                     }
-                    return true;
+                    return canBuy;
                 },
                 //We can check to see if this is bought at the Clearing.
                 effect: function() {}
-
             }],
         ])
 

--- a/src/types/areaData.ts
+++ b/src/types/areaData.ts
@@ -1,12 +1,12 @@
 import type { SpecialAreaId, Zone } from "@/enums/areaEnums"
-import type Decimal from "break_infinity.js"
 
 export interface AreaData {
-    areaSpecialID?: SpecialAreaId
-    areaName: string,
-    zone: Zone,
-    description: string,
-    killCount: number,
-    scoutThreshold: number,
-    interactable: false
+    areaSpecialID?: SpecialAreaId;
+    customFunc?: Function;
+    areaName: string;
+    zone: Zone;
+    description: string;
+    killCount: number;
+    scoutThreshold: number;
+    interactable: false;
 }

--- a/src/types/gameFlag.ts
+++ b/src/types/gameFlag.ts
@@ -1,0 +1,4 @@
+export interface GameFlag {
+    description: String;
+    flagOn: boolean;
+}

--- a/src/types/gameFlag.ts
+++ b/src/types/gameFlag.ts
@@ -1,4 +1,4 @@
 export interface GameFlag {
-    description: String;
-    state: boolean;
+    description: String; //helps for human readability, unless we want to make a reference file somewhere.
+    state: boolean; 
 }

--- a/src/types/gameFlag.ts
+++ b/src/types/gameFlag.ts
@@ -1,4 +1,4 @@
 export interface GameFlag {
     description: String;
-    flagOn: boolean;
+    state: boolean;
 }

--- a/src/types/gameFlag.ts
+++ b/src/types/gameFlag.ts
@@ -1,4 +1,0 @@
-export interface GameFlag {
-    description: String; //helps for human readability, unless we want to make a reference file somewhere.
-    state: boolean; 
-}

--- a/src/types/saveArrays.ts
+++ b/src/types/saveArrays.ts
@@ -11,6 +11,5 @@ export interface SaveKillsArray {
 
 export interface SavedGameFlags {
     key: number,
-    description: string,
     state: boolean
 }

--- a/src/types/saveArrays.ts
+++ b/src/types/saveArrays.ts
@@ -1,0 +1,16 @@
+export interface SaveUpgradeArray {
+    key: number,
+    unlocked: boolean,
+    bought: boolean,
+}
+
+export interface SaveKillsArray {
+    key: string,
+    kills: number,
+}
+
+export interface SavedGameFlags {
+    key: number,
+    description: string,
+    state: boolean
+}

--- a/src/types/saveKillsArray.ts
+++ b/src/types/saveKillsArray.ts
@@ -1,4 +1,0 @@
-export interface SaveKillsArray {
-    key: string,
-    kills: number,
-}

--- a/src/types/saveUpgradeArray.ts
+++ b/src/types/saveUpgradeArray.ts
@@ -1,5 +1,0 @@
-export interface SaveUpgradeArray {
-    key: number,
-    unlocked: boolean,
-    bought: boolean,
-}


### PR DESCRIPTION
This PR adds a *ton*, namely:

- Add `GameFlags.ts` and supporting files. This manages a gameFlags system for events. I've moved over the Soul unlock to this system, but the starting cutscenes could be adapted to use this in the future.
- Added `customFunc` to the area class. This allows areas to run a function on you entering them, such as calling events and setting Flags.
- Updated Upgrades to properly utilitize the show/hide functionality built into them.
- Created a fledgling system to hold resources, currently found in `player.ts`. This is currently unused.
- Added the events and everything needed for the shrine unlock sequence. Flavor text can be tweaked/changed, my brain could just not write when I was doing this, lol.
- Added gameFlags to be properly saved/loaded as everything else, with a simple boot strap initializer on starting a new file.

You're going to have to start a new File to make everything work. Feel free to modify story text as needed, everything is mostly temporary for now.