### PR TITLE
Resource improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,12 +22,16 @@
                         <span :class="{ 'tab-selected': activeTabOverworld === Tab.COMBAT, 'in-combat': combatStore.activeCombat }" @click="showTabOverworld(Tab.COMBAT)" class="tab">
                             Combat
                         </span>
+                        <span :class="{ 'tab-selected': activeTabOverworld === Tab.INVENTORY }" @click="showTabOverworld(Tab.INVENTORY)" class="tab">
+                            Inventory
+                        </span>
                     </div>
                 </div>
 
                 <div v-show="!(mapStore.selectedNode.data.areaSpecialID)" class="content-container">
                     <InfoPanel v-bind:active="activeTabOverworld" />
                     <CombatPanel v-bind:active="activeTabOverworld" />
+                    <UpgradePanel v-bind:active="activeTabOverworld" />
                 </div>
 
 
@@ -37,7 +41,7 @@
                         <span :class="{ 'tab-selected': activeTabHome === Tab.OVERVIEW }" @click="showTabHome(Tab.OVERVIEW)" class="tab">
                             Home
                         </span>
-                        <span :class="{ 'tab-selected': activeTabHome === Tab.HOME_UPGRADES }" @click="showTabHome(Tab.HOME_UPGRADES)" class="tab">
+                        <span :class="{ 'tab-selected': activeTabHome === Tab.INVENTORY }" @click="showTabHome(Tab.INVENTORY)" class="tab">
                             Upgrades
                         </span>
                         <span v-if="gameFlags.flagList.get(FlagEnum.EXPLORE_UNLOCKED)" :class="{ 'tab-selected': activeTabHome === Tab.EXPLORE }" @click="showTabHome(Tab.EXPLORE)" class="tab">
@@ -52,6 +56,7 @@
 
                 <div v-show="mapStore.selectedNode.data.areaSpecialID === SpecialAreaId.HOME" class="content-container">
                     <BasePanel v-bind:active="activeTabHome" />
+                    <UpgradePanel v-bind:active="activeTabHome" />
                     <ExplorePanel v-bind:active="activeTabHome" />
                 </div>
             </div>
@@ -110,6 +115,7 @@
 
 <script setup lang="ts">
     import ExplorePanel from './components/ExplorePanel.vue' 
+    import UpgradePanel from './components/UpgradePanel.vue' 
     import CombatPanel from './components/CombatPanel.vue'
     import SoulUpgradePanel from './components/SoulUpgradePanel.vue'
     import OvermapPanel from './components/OvermapPanel.vue';
@@ -169,6 +175,7 @@
     }
 
     function showTabHome (tab:Tab) {
+        console.log(tab);
         activeTabHome.value = tab;
     }
 

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -253,7 +253,9 @@ button:hover {
 }
 
 .vue-flow {
-    background: #bbeaff;
+    /* background: #bbeaff; */
+    /* background: #FCF5E5; */
+    background: #ebd5b3
 }
 
 

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -282,3 +282,7 @@ button:hover {
     cursor: pointer;
     color: #9ec93d;
 }
+
+.divider {
+    border-bottom: 1px solid;
+}

--- a/src/components/BasePanel.vue
+++ b/src/components/BasePanel.vue
@@ -6,13 +6,13 @@
         <div v-else class="home-box">
             <div class = "base-pic"></div>
             <div class = "base-text">
-                <span v-if="gameFlags.flagList.get(FlagEnum.SHRINE_UNLOCKED)?.state">The statue's eyes glow blue as it rests in the center of the cave.</span>
+                <span v-if="gameFlags.flagList.get(FlagEnum.SHRINE_UNLOCKED)">The statue's eyes glow blue as it rests in the center of the cave.</span>
                 <span v-else>A dark, drafty cave, with little in the way of comfort. It wouldn't hurt to make this place a little bit more like a proper home...</span>
                 <PlayerHpBar style="margin-bottom: 5px; margin-top: 8px;"/>
                 <span style="color:green">Current HP Regen: {{ player.getHPRegen }}</span>
                 <span style=" color:gold">Current Energy Regen: {{ player.getEnergyRegen }}</span>
             </div>
-            <div class = "upgrades">
+            <!-- <div class = "upgrades">
                 <UpgradeButton v-for="(item) in upgradeStore.getBuyableHomeUpgrades"
                     :upgrade_key="item[0]" 
                     :show="item[1].show"
@@ -25,7 +25,7 @@
                     :costFunc="item[1].costFunc"
                     :effect="item[1].effect"
                 />
-            </div>
+            </div> -->
         </div>
     </div>
 </template>

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -1,21 +1,23 @@
 <template>
-    <div @mouseenter="nodeMouseover()" @mouseleave="nodeMouseover(true)" class="node-boundary" :class="{ 'selected-node': mapStore.selectedNode.id === props.id}">
+    <div @mouseenter="nodeMouseover()" 
+    @mouseleave="nodeMouseover(true)" 
+    class="node-boundary" 
+    :class="[{ 'selected-node': mapStore.selectedNode.id === props.id}, zoneClass, {'special': specialZone}]">
         {{ data.areaName }}
     </div>
 </template>
 
 <script setup lang="ts">
+    import { Zone } from '@/enums/areaEnums';
     import { useMapStore } from '@/stores/mapStore.js';
     import { useVueFlow, type GraphNode } from '@vue-flow/core';
-    import { ref } from 'vue';
+    import { computed, ref } from 'vue';
     
     const mapStore = useMapStore();
 
     const name = "customNode";
     
     //TODO: This wont work. Need to move all the tooltip stuff to the overmap panel, and do something with emitting events for mouse-overe'd nodes
-
-  //TODO: Could style based off of zone of Area in the future.
     const props = defineProps({
         id: String,
         data: {
@@ -23,6 +25,20 @@
             required: true,
         },
     }) 
+
+    
+    const zoneClass = computed(() => {
+        const zone = props.data.zone as Zone || Zone.FOREST;
+        //Add zones in as they are made.
+        switch(zone) {
+            case Zone.FOREST: return "forest";
+            case Zone.DEEP_FOREST: return "deep-forest";
+        }
+        
+        return "forest"
+    })
+
+    const specialZone = computed(() => props.data.areaSpecialID)
 
     const nodeMouseover = function(reset?:boolean) {
         if(!reset) {
@@ -44,21 +60,28 @@
 </script>
 <style>
   .node-boundary {
-    border: 2px solid black;
     padding: 10px;
     border-radius: 20px;
     width: 100px;
     font-size: 24px;
     text-align: center;
-    border-width: 3px;
     border-style: solid;
-    background-color: #9ec93d;
+    
     color: #222; 
     cursor: pointer;
   }
 
+  .forest {
+    border: 2px solid black;
+    background-color: #9ec93d;
+  }
 
+  .special {
+    border-width: 4px !important;
+    border-color:rgb(242, 255, 0);
+  }
 
-
-
+  .selected-node {
+    background-color:rgb(0, 140, 255);
+  }
 </style>

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -78,7 +78,7 @@
 
   .special {
     border-width: 4px !important;
-    border-color:rgb(242, 255, 0);
+    border-color:rgb(223, 186, 0);
   }
 
   .selected-node {

--- a/src/components/ExplorePanel.vue
+++ b/src/components/ExplorePanel.vue
@@ -18,7 +18,6 @@
             </div>
         </div>
     </div>
-    <!-- <EventDisplay v-if="!!isEventActive" :area-event="activeEvent" @event-finished="eventCleanup()"></EventDisplay> -->
 </template>
 
 
@@ -32,21 +31,8 @@ import { useDecks } from '@/stores/deckStore';
 const name = "areaActionsPanel";
 
 const player = usePlayer();
-const combatStore = useCombatStore();
 const mapStore = useMapStore();
 const exploreDeck = useDecks();
-// let isEventActive = ref(false);
-// let activeEvent = {} as AreaEvent;
-// const testEvent = {
-//     id: "1",
-//     zone: Zone.FOREST,
-//     eventText: "You found some Soul, woo!",
-//     choices:[{id: 1, label: "Okay! (+10 Soul)"}],
-//     eventCallback: function(choice: number) {
-//         player.addSoul(10)
-//         console.log(choice)
-//     }
-// } as AreaEvent;
 
 let props = defineProps({
     active: String
@@ -59,9 +45,6 @@ const pullCard = function () {
     }
 }
 
-// const eventCleanup = function():void {
-//     isEventActive.value = false;
-// }
 </script>
 <style>
     .area-box {

--- a/src/components/NodeTooltip.vue
+++ b/src/components/NodeTooltip.vue
@@ -46,12 +46,10 @@
     const yStyle = computed(() => (y.value-height.value-7)+'px');
 
 
+
 </script>
 
 <style>
-  .selected-node {
-    background:grey;
-  }
   .node-tooltip {
         z-index: 100;
         min-width: 300px;

--- a/src/components/UpgradeButton.vue
+++ b/src/components/UpgradeButton.vue
@@ -16,7 +16,6 @@
 
 
 <script setup lang="ts">
-import Decimal from 'break_infinity.js';
 import { computed, ref, type PropType } from 'vue';
 import { usePlayer } from '@/stores/player';
 import { useUpgradeStore } from '@/stores/upgradeStore';
@@ -86,10 +85,6 @@ const buy = function() {
         z-index: 1;
         top: -5px;
         left: 105%;
-    }
-
-    .divider {
-        border-bottom: 1px solid;
     }
 
     .tooltip-button {

--- a/src/components/UpgradePanel.vue
+++ b/src/components/UpgradePanel.vue
@@ -1,0 +1,76 @@
+<template>
+    <div v-show="active === Tab.INVENTORY">
+        <!-- Inventory --->
+        <span class="title">Resources:</span>
+        <div class="inventory-box">
+            <span v-for="(item) in player.resources.entries()" class="resource"><b>{{ item[0] }}</b> : {{ item[1].amount }} / {{ item[1].max }}</span>
+        </div>
+        <div class="divider"></div>
+        <div v-show="mapStore.selectedNode.data.areaSpecialID === SpecialAreaId.HOME" class="home-box">
+            <div class = "upgrades">
+                <UpgradeButton v-for="(item) in upgradeStore.getBuyableHomeUpgrades"
+                    :upgrade_key="item[0]" 
+                    :show="item[1].show"
+                    :is_bought="item[1].bought"
+                    :upgrade_category="item[1].category"
+                    :title="item[1].title"
+                    :flavor="item[1].flavor"
+                    :effect_description="item[1].effectDescription"
+                    :cost_description="item[1].costDescription"
+                    :costFunc="item[1].costFunc"
+                    :effect="item[1].effect"
+                />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import { Tab } from '@/enums/panels';
+    import { useUpgradeStore } from '@/stores/upgradeStore';
+    import UpgradeButton from './UpgradeButton.vue';
+    import { useMapStore } from '@/stores/mapStore';
+    import { SpecialAreaId } from '@/enums/areaEnums';
+    import { usePlayer } from '@/stores/player';
+
+    const name = "upgradePanel";
+    const mapStore = useMapStore();
+    const player = usePlayer();
+
+    let props = defineProps({
+        active: String
+    })
+
+    const upgradeStore = useUpgradeStore();
+
+
+</script>
+<style>
+    .upgrades {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .home-box {
+        margin-top: 10px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .title {
+        font-weight: 500px;
+        font-size: 32px;
+    }
+
+    .inventory-box {
+        display:flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        margin:8px 0;
+        .resource {
+            font-size: 22px;
+            margin: 0 8px;
+        }
+    }
+</style>

--- a/src/components/UpgradePanel.vue
+++ b/src/components/UpgradePanel.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-show="active === Tab.INVENTORY">
-        <!-- Inventory --->
+        <!-- Inventory -->
         <span class="title">Resources:</span>
         <div class="inventory-box">
             <span v-for="(item) in player.resources.entries()" class="resource"><b>{{ item[0] }}</b> : {{ item[1].amount }} / {{ item[1].max }}</span>

--- a/src/enums/areaEnums.ts
+++ b/src/enums/areaEnums.ts
@@ -5,5 +5,6 @@ export enum SpecialAreaId {
 
 export enum Zone {
     SPECIAL = "special",
-    FOREST = "forest"
+    FOREST = "forest",
+    DEEP_FOREST = "deep_forest"
 }

--- a/src/enums/panels.ts
+++ b/src/enums/panels.ts
@@ -10,7 +10,7 @@ export enum Tab {
 
     //Home
     OVERVIEW = "overview",
-    HOME_UPGRADES = "upgrades",
+    INVENTORY = "inventory",
     EXPLORE = "explore",
 
     //Soul

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -21,6 +21,7 @@ export const usePlayer = defineStore('player', () => {
 
 
     // -- Stats --
+    //TODO: Possibly move energy and Soul over to new Resource system.
     const currencies = ref({
         soul: new Decimal("0"),
         maxSoul: new Decimal("10"),
@@ -91,8 +92,6 @@ export const usePlayer = defineStore('player', () => {
 
 
     })
-
-
 
     // -- Getters/Computeds --
     const getAtk = computed(() => playerStats.value.attack)
@@ -209,6 +208,30 @@ export const usePlayer = defineStore('player', () => {
         }
     }
 
+    function checkResourceCost(amnt:number, type:ResourceEnum): boolean {
+        return (resources.value.get(type)?.amount || 0) >= amnt;
+    }
+
+    function payResource(cost:number, type:ResourceEnum): boolean {
+        const resource = resources.value.get(type);
+        if(resource?.amount && resource?.amount  >= cost) {
+            resources.value.set(type, {amount: resource.amount-cost, max: resource.max})
+            return true;
+        }
+        return false;
+    }
+
+    function gainResource(amnt:number, type:ResourceEnum) {
+        const resource = resources.value.get(type);
+        if(resource?.max) {
+            if((resource.amount || 0) + amnt >= resource.max) {
+                resources.value.set(type, {amount: resource.max, max:resource.max})
+            } else {
+                resources.value.set(type, {amount: resource.amount+amnt, max:resource.max})
+            }
+        }
+    }
+
     return {
         //Stats
         currencies, name, tails, playerStats, gameStage, furthestStage, loaded, firstMove, deniedSoul, resources,
@@ -217,6 +240,7 @@ export const usePlayer = defineStore('player', () => {
         getHPRegen, getEnergyRegen,
         // Actions
         addSoul, subtractSoul, damage, payEnergy, enoughSoul, enoughScouted, enoughKills, enoughEnergy, addBaseAtk, addBaseDef,
-        addBaseHealth, modifySpeed, modifyMaxSoul, addTail, addFood, addHPRegen, addEnergyRegen
+        addBaseHealth, modifySpeed, modifyMaxSoul, addTail, addFood, addHPRegen, addEnergyRegen, checkResourceCost, payResource,
+        gainResource
     }
 })

--- a/src/stores/upgradeStore.ts
+++ b/src/stores/upgradeStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { usePlayer } from './player'
 import { type Upgrade, UpgradeCategory } from '@/types/upgrade'
+import { ResourceEnum } from '@/types/resources';
 
 export const useUpgradeStore = defineStore('upgradeStore', {
     state: () => ({
@@ -116,30 +117,15 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 title: "Makeshift Rope",
                 flavor: "Find a long enough vine to wrap around the strange statue so you can drag it home.",
                 effectDescription: "Take this back to the Strange Clearing.",
-                costDescription:"Costs 5 Fiber. (For now, costs 10 soul instead.)",
-                // costFunc: (buyCheck: boolean) => {
-                //     const player = usePlayer();
-                //     const fiber = player.resources.get(ResourceEnum.FIBER) || 0
-                //     if (fiber < 5) {
-                //         return false;
-                //     }
-
-                //     if(!buyCheck) {
-                //         player.resources.set(ResourceEnum.FIBER, fiber-5) 
-                //     }
-                //     return true;
-                // },
+                costDescription:"Costs 5 Fiber.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
-                    const canBuy = player.enoughSoul(10);
-                    if (buyCheck) {
-                        return canBuy;
-                    }
 
-                    if(canBuy) {
-                        player.subtractSoul(10);  
+                    if(!buyCheck) {
+                        return player.payResource(5, ResourceEnum.FIBER)
+                    } else {
+                        return player.checkResourceCost(5, ResourceEnum.FIBER);
                     }
-                    return canBuy;
                 },
                 //We can check to see if this is bought at the Clearing.
                 effect: function() {}

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -1,6 +1,6 @@
 export enum ResourceEnum {
-    FIBER = "fiber",
-    STONE = "stone"
+    FIBER = "Fiber",
+    STONE = "Stone"
 }
 
 export interface ResourceEntry {


### PR DESCRIPTION
This PR finishes up a few things so I can get them onto master while I continue working:

- Add Inventory tab to Overworld and Home. Upgrades only display while you're at home.
- Add resources map to player.ts
- tweak customNode with some basic logic so we can style it based on the Zone the node is in, will continue to work on in a following branch

![image](https://github.com/cm97878/Foxgame/assets/58402624/f3300e77-6b5d-4134-a9a0-9c279634e238)
