### PR TITLE
Soul Upgrades & Zones

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,8 +144,6 @@
     const mapStore = useMapStore();
     const gameFlags = useGameFlags();
 
-    const name = "app";
-
     const activePanel = ref(Panels.WORLD);
     const activeTabOverworld = ref(Tab.COMBAT);
     const activeTabHome = ref(Tab.OVERVIEW);

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,7 @@
                 <div v-show="!(mapStore.selectedNode.data.areaSpecialID)" class="content-container">
                     <InfoPanel v-bind:active="activeTabOverworld" />
                     <CombatPanel v-bind:active="activeTabOverworld" />
-                    <UpgradePanel v-bind:active="activeTabOverworld" />
+                    <InventoryPanel v-bind:active="activeTabOverworld" />
                 </div>
 
 
@@ -56,7 +56,7 @@
 
                 <div v-show="mapStore.selectedNode.data.areaSpecialID === SpecialAreaId.HOME" class="content-container">
                     <BasePanel v-bind:active="activeTabHome" />
-                    <UpgradePanel v-bind:active="activeTabHome" />
+                    <InventoryPanel v-bind:active="activeTabHome" />
                     <ExplorePanel v-bind:active="activeTabHome" />
                 </div>
             </div>
@@ -115,7 +115,7 @@
 
 <script setup lang="ts">
     import ExplorePanel from './components/ExplorePanel.vue' 
-    import UpgradePanel from './components/UpgradePanel.vue' 
+    import InventoryPanel from './components/InventoryPanel.vue' 
     import CombatPanel from './components/CombatPanel.vue'
     import SoulUpgradePanel from './components/SoulUpgradePanel.vue'
     import OvermapPanel from './components/OvermapPanel.vue';

--- a/src/components/BasePanel.vue
+++ b/src/components/BasePanel.vue
@@ -42,8 +42,6 @@ import PlayerHpBar from './playerHPBar.vue';
 import { useGameFlags } from '@/stores/gameFlags';
 import { FlagEnum } from "@/enums/flagEnum"
 
-const name = "basePanel";
-
 const mapStore = useMapStore();
 const player = usePlayer();
 const upgradeStore = useUpgradeStore();

--- a/src/components/CombatPanel.vue
+++ b/src/components/CombatPanel.vue
@@ -81,8 +81,6 @@ import PlayerHpBar from './playerHPBar.vue';
 const player = usePlayer();
 const combatStore = useCombatStore();
 
-const name = "combatpanel";
-
 const props = defineProps({
     active: String
 })

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -14,8 +14,6 @@
     import { computed } from 'vue';
     
     const mapStore = useMapStore();
-
-    const name = "customNode";
     
     //TODO: This wont work. Need to move all the tooltip stuff to the overmap panel, and do something with emitting events for mouse-overe'd nodes
     const props = defineProps({

--- a/src/components/CustomNode.vue
+++ b/src/components/CustomNode.vue
@@ -11,7 +11,7 @@
     import { Zone } from '@/enums/areaEnums';
     import { useMapStore } from '@/stores/mapStore.js';
     import { useVueFlow, type GraphNode } from '@vue-flow/core';
-    import { computed, ref } from 'vue';
+    import { computed } from 'vue';
     
     const mapStore = useMapStore();
 
@@ -33,6 +33,7 @@
         switch(zone) {
             case Zone.FOREST: return "forest";
             case Zone.DEEP_FOREST: return "deep-forest";
+            case Zone.RIVERBANK: return "riverbank";
         }
         
         return "forest"
@@ -74,6 +75,16 @@
   .forest {
     border: 2px solid black;
     background-color: #9ec93d;
+  }
+
+  .deep-forest {
+    border: 2px solid #006608;
+    background-color: #00ba06;
+  }
+
+  .riverbank {
+    border: 2px solid #002861;
+    background-color: #0091ff;
   }
 
   .special {

--- a/src/components/EventDisplay.vue
+++ b/src/components/EventDisplay.vue
@@ -7,7 +7,6 @@
 
 <script setup lang="ts">
     import type { AreaEvent }  from '@/types/areaEvent'
-    const name = "EventDisplay"
 
     let props = defineProps<{
         areaEvent: AreaEvent

--- a/src/components/ExplorePanel.vue
+++ b/src/components/ExplorePanel.vue
@@ -28,8 +28,6 @@ import { Tab } from '@/enums/panels';
 import { useMapStore } from '@/stores/mapStore';
 import { useDecks } from '@/stores/deckStore';
 
-const name = "areaActionsPanel";
-
 const player = usePlayer();
 const mapStore = useMapStore();
 const exploreDeck = useDecks();

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -12,8 +12,6 @@
 import { Tab } from '@/enums/panels';
 import { useMapStore } from '@/stores/mapStore';
 
-const name = "infopanel";
-
 const mapStore = useMapStore();
 
 const props = defineProps({

--- a/src/components/InventoryPanel.vue
+++ b/src/components/InventoryPanel.vue
@@ -33,7 +33,7 @@
     import { SpecialAreaId } from '@/enums/areaEnums';
     import { usePlayer } from '@/stores/player';
 
-    const name = "upgradePanel";
+    const name = "inventoryPanel";
     const mapStore = useMapStore();
     const player = usePlayer();
 

--- a/src/components/InventoryPanel.vue
+++ b/src/components/InventoryPanel.vue
@@ -32,8 +32,6 @@
     import { useMapStore } from '@/stores/mapStore';
     import { SpecialAreaId } from '@/enums/areaEnums';
     import { usePlayer } from '@/stores/player';
-
-    const name = "inventoryPanel";
     const mapStore = useMapStore();
     const player = usePlayer();
 

--- a/src/components/NodeTooltip.vue
+++ b/src/components/NodeTooltip.vue
@@ -32,8 +32,6 @@
     import { useMapStore } from '@/stores/mapStore';
     import { useMouse, useElementSize } from '@vueuse/core'
     import { computed, ref } from 'vue';
-
-    const name = "nodetooltip"
     const tooltip = ref(null);
 
     const mapStore = useMapStore();

--- a/src/components/NodeTooltip.vue
+++ b/src/components/NodeTooltip.vue
@@ -14,8 +14,9 @@
             </div>
             <hr class="solid">
             Enemies: 
-            <span v-for="item, index in mapStore.enemyList">
-                {{ item.name }}<span v-if="index != (mapStore.enemyList.length - 1)">, </span>
+            <span v-for="item, index in mapStore.enemyList.get(mapStore.mouseoverNode?.data.zone)">
+                {{ item.name }},
+                <!-- {{ item.name }}<span v-if="index != (mapStore.enemyList.length - 1)">, </span> -->
             </span>
 
             <div 

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -1,15 +1,5 @@
 <template>
     <div id="maps_container">
-        <!-- <div id="map_keynodes">
-            {{ mapStore.getAreaName }} <br />
-            <div v-show="mapStore.isSpecial">
-                special 
-                <br />
-            </div>
-            <div v-show="!mapStore.isSpecial">
-                {{ mapStore.getDescription }} {{ mapStore.getDescAppend }}
-            </div>
-        </div> -->
         <div id="vf-map">
             <VueFlow :nodes="mapStore.mapNodes" class="general_outline">
                 <template #node-custom ="{ data, id }">
@@ -70,7 +60,7 @@ onNodeClick((node) => {
         //TODO: Make this check use gameFlags
         if(player.firstMove) {
             player.firstMove = false;
-            combatStore.startCombat(mapStore.enemyList[0]);
+            combatStore.startCombat(mapStore.enemyList.get(Zone.FOREST)[0]);
             eventStore.callCutscene(eventStore.cutscenes.get("firstMove"));
         } else if(!!chosenNode?.data?.customFunc) {
             chosenNode.data.customFunc();

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -24,8 +24,6 @@ import { storeToRefs } from 'pinia';
 import { watch } from 'vue';
 import { useCombatStore } from '@/stores/combatStore';
 
-
-const name = "overmappanel";
 const mapStore = useMapStore();
 const player = usePlayer();
 const eventStore = useEventStore();

--- a/src/components/OvermapPanel.vue
+++ b/src/components/OvermapPanel.vue
@@ -65,7 +65,7 @@ onNodeClick((node) => {
         } else if(!!chosenNode?.data?.customFunc) {
             chosenNode.data.customFunc();
         } else if(!(!!chosenNode?.data?.areaSpecialID)) {
-            mapStore.callRandomEncounter(Zone.FOREST)
+            mapStore.callRandomEncounter(chosenNode.data.zone || Zone.FOREST)
         } 
 
         

--- a/src/components/SoulUpgradePanel.vue
+++ b/src/components/SoulUpgradePanel.vue
@@ -21,8 +21,6 @@
 import UpgradeButton from './UpgradeButton.vue';
 import { useUpgradeStore } from '@/stores/upgradeStore';
 
-const name = "soulUpgradePanel";
-
 const upgrade = useUpgradeStore();
 
 let props = defineProps({

--- a/src/components/SoulUpgradePanel.vue
+++ b/src/components/SoulUpgradePanel.vue
@@ -11,6 +11,8 @@
             :cost_description="item[1].costDescription"
             :costFunc="item[1].costFunc"
             :effect="item[1].effect"
+            :repeatable="item[1].repeatable"
+            :level="item[1].level"
         />
     </div>
 </template>

--- a/src/components/UpgradeButton.vue
+++ b/src/components/UpgradeButton.vue
@@ -1,6 +1,6 @@
 <template>
-    <button @click="buy()" class="tooltip-button" :class="{bought: is_bought, unbuyable: !canAfford }" @mouseenter="hover = true" @mouseleave="hover = false">
-        {{ title }}
+    <button @click="buy()" class="tooltip-button" :class="[boughtType, {unbuyable: !canAfford }]" @mouseenter="hover = true" @mouseleave="hover = false">
+        {{ fullTitle }}
         <Transition name="upgrade-tooltip">
             <!-- sets hover false on mouseenter here 'cause otherwise it can get 'stuck' and feel weird -->
             <div v-show="hover" class="tooltiptext" @mouseenter="hover = false">
@@ -24,10 +24,9 @@ import { UpgradeCategory } from '@/types/upgrade';
 
 const name = "upgradebutton";
 
-const hover = ref(false);
-
 const player = usePlayer();
 const upgrades = useUpgradeStore();
+
 let props = defineProps({
     show: Boolean,
     is_bought: Boolean,
@@ -38,17 +37,44 @@ let props = defineProps({
     cost_description: String,
     upgrade_key: Number,
     costFunc: Function, // (buyCheck: boolean) => boolean;
-    effect: Function
+    effect: Function,
+    repeatable: Boolean,
+    level: Number
+})
+
+const hover = ref(false);
+const boughtType = computed(() => {
+    if(props.repeatable && props.is_bought) {
+        return "multi-bought"
+    } else if (props.is_bought) {
+        return "bought"
+    } else {
+        return ""
+    }
 })
 
 
-const canAfford = computed(() => props.costFunc ? props.costFunc(true) : false)
+const canAfford = computed(() => props.costFunc ? props.costFunc(true, props.level || -1) : false)
+const fullTitle = computed(() => {
+    const level = props.level || 0;
+    return level > 1 ? props.title + " \(" + (level-1) + "\)"  : props.title
+})
 
 
 const buy = function() {
     if(props.upgrade_key && canAfford.value && props.costFunc) {
         let temp = props.upgrade_category === UpgradeCategory.SOUL ? upgrades.soul.get(props.upgrade_key) : upgrades.home.get(props.upgrade_key);
         if(temp) {
+            //repeatables
+            if(temp.repeatable && !!temp.level) {
+                props.costFunc(false, temp.level)
+                temp.bought = true
+                temp.level = temp.level+1
+                props.upgrade_category === UpgradeCategory.SOUL ? upgrades.soul.set(props.upgrade_key, temp) : upgrades.home.set(props.upgrade_key, temp);
+                if(props.effect) {
+                    props.effect();
+                }
+            }
             if(!temp.bought) {
                 // Actually buy the upgrade.
                 props.costFunc(false)
@@ -94,6 +120,11 @@ const buy = function() {
 
     .bought {
         background-color: rgb(41, 163, 47) !important;
+    }
+
+    .multi-bought {
+        border: 3px solid rgb(41, 163, 47);
+        outline: none !important;
     }
 
     .unbuyable {

--- a/src/components/UpgradeButton.vue
+++ b/src/components/UpgradeButton.vue
@@ -21,9 +21,6 @@ import { usePlayer } from '@/stores/player';
 import { useUpgradeStore } from '@/stores/upgradeStore';
 import { UpgradeCategory } from '@/types/upgrade';
 
-
-const name = "upgradebutton";
-
 const player = usePlayer();
 const upgrades = useUpgradeStore();
 

--- a/src/components/playerHPBar.vue
+++ b/src/components/playerHPBar.vue
@@ -10,8 +10,6 @@ import { usePlayer } from '@/stores/player';
 import { displayDecimal } from '@/utils/utils';
 const player = usePlayer();
 
-const name = "playerHPBar";
-
 </script>
 
 <style>

--- a/src/enums/areaEnums.ts
+++ b/src/enums/areaEnums.ts
@@ -6,5 +6,6 @@ export enum SpecialAreaId {
 export enum Zone {
     SPECIAL = "special",
     FOREST = "forest",
-    DEEP_FOREST = "deep_forest"
+    DEEP_FOREST = "deep_forest",
+    RIVERBANK = "riverbank"
 }

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -31,7 +31,7 @@ export const useMapStore = defineStore('mapStuff', () => {
 
     // -- State --
 
-    //This should be an a group of arrays. Each item should have a Zone and an attached array of enemies as an encounter list for it.
+    //TODO: Properly balance new zone enemies.
     const enemyList = new Map<Zone, Enemy[]>([
         [Zone.FOREST, [{
             name: "Rat",
@@ -59,9 +59,43 @@ export const useMapStore = defineStore('mapStuff', () => {
             spd: 100,
             soulAbsorb: new Decimal("1"),
             soulKill: new Decimal("1"),
-        }],
-
-        ]
+        }]],
+        [Zone.DEEP_FOREST, [{
+            name: "Creeper Vines",
+            attack: new Decimal("35"),
+            defense: new Decimal("45"),
+            maxHP: new Decimal("120"),
+            spd: 300,
+            soulAbsorb: new Decimal("15"),
+            soulKill: new Decimal("15"),
+        },
+        {
+            name: "Stag",
+            attack: new Decimal("50"),
+            defense: new Decimal("35"),
+            maxHP: new Decimal("100"),
+            spd: 300,
+            soulAbsorb: new Decimal("15"),
+            soulKill: new Decimal("15"),
+        }]],
+        [Zone.RIVERBANK, [{
+            name: "Hawk",
+            attack: new Decimal("10"),
+            defense: new Decimal("4"),
+            maxHP: new Decimal("25"),
+            spd: 200,
+            soulAbsorb: new Decimal("5"),
+            soulKill: new Decimal("5"),
+        },
+        {
+            name: "Otter",
+            attack: new Decimal("7"),
+            defense: new Decimal("5"),
+            maxHP: new Decimal("40"),
+            spd: 300,
+            soulAbsorb: new Decimal("5"),
+            soulKill: new Decimal("5"),
+        }]]
     ])
 
     const mapNodes = ref([{
@@ -373,17 +407,27 @@ export const useMapStore = defineStore('mapStuff', () => {
 
     function callRandomEncounter(zone: Zone): void {
         let list = [] as Array<Enemy>;
+        debugger;
         switch(zone) {
             //TODO: Add Deep Forest Zone and spawn list!
-            case Zone.FOREST: { list = enemyList.get(Zone.FOREST) || [] }
-            case Zone.DEEP_FOREST: { list = enemyList.get(Zone.DEEP_FOREST) || [] }
-            case Zone.RIVERBANK: { list = enemyList.get(Zone.RIVERBANK) || [] }
-
-            if(!!list && list.length > 1) {
-                const encounterIdx = Math.floor(Math.random() * list.length );
-                const combatStore = useCombatStore();
-                combatStore.startCombat(list[encounterIdx]);
+            case Zone.FOREST: { 
+                list = enemyList.get(Zone.FOREST) || []
+                break;
             }
+            case Zone.DEEP_FOREST: { 
+                list = enemyList.get(Zone.DEEP_FOREST) || [] 
+                break;
+            }
+            case Zone.RIVERBANK: { 
+                list = enemyList.get(Zone.RIVERBANK) || [] 
+                break;
+            }
+        }
+        if(!!list && list.length > 1) {
+            debugger;
+            const encounterIdx = Math.floor(Math.random() * list.length );
+            const combatStore = useCombatStore();
+            combatStore.startCombat(list[encounterIdx]);
         }
     }
 

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -32,33 +32,37 @@ export const useMapStore = defineStore('mapStuff', () => {
     // -- State --
 
     //This should be an a group of arrays. Each item should have a Zone and an attached array of enemies as an encounter list for it.
-    const enemyList = [{
-        name: "Rat",
-        attack: new Decimal("2"),
-        defense: new Decimal("0"),
-        maxHP: new Decimal("7"),
-        spd: 300,
-        soulAbsorb: new Decimal("1"),
-        soulKill: new Decimal("1"),
-    },
-    {
-        name: "Dog",
-        attack: new Decimal("3"),
-        defense: new Decimal("1"),
-        maxHP: new Decimal("10"),
-        spd: 300,
-        soulAbsorb: new Decimal("1"),
-        soulKill: new Decimal("1"),
-    },
-    {
-        name: "Mouse",
-        attack: new Decimal("1"),
-        defense: new Decimal("0"),
-        maxHP: new Decimal("5"),
-        spd: 100,
-        soulAbsorb: new Decimal("1"),
-        soulKill: new Decimal("1"),
-    }] as Array<Enemy>;
+    const enemyList = new Map<Zone, Enemy[]>([
+        [Zone.FOREST, [{
+            name: "Rat",
+            attack: new Decimal("2"),
+            defense: new Decimal("0"),
+            maxHP: new Decimal("7"),
+            spd: 300,
+            soulAbsorb: new Decimal("1"),
+            soulKill: new Decimal("1"),
+        },
+        {
+            name: "Chipmunk",
+            attack: new Decimal("3"),
+            defense: new Decimal("1"),
+            maxHP: new Decimal("10"),
+            spd: 300,
+            soulAbsorb: new Decimal("1"),
+            soulKill: new Decimal("1"),
+        },
+        {
+            name: "Mouse",
+            attack: new Decimal("1"),
+            defense: new Decimal("0"),
+            maxHP: new Decimal("5"),
+            spd: 100,
+            soulAbsorb: new Decimal("1"),
+            soulKill: new Decimal("1"),
+        }],
+
+        ]
+    ])
 
     const mapNodes = ref([{
         id: '1',
@@ -219,7 +223,7 @@ export const useMapStore = defineStore('mapStuff', () => {
         type: 'custom',
         data: {
             areaName: "Faded Trail (W-E)",
-            zone: Zone.FOREST,
+            zone: Zone.RIVERBANK,
             description: "A stone-marked trail runs west to east, with thick brambles meandering along to its north.",
             killCount: 0,
             scoutThreshold: 1
@@ -233,7 +237,7 @@ export const useMapStore = defineStore('mapStuff', () => {
         type: 'custom',
         data: {
             areaName: "Cliffside Clearing",
-            zone: Zone.FOREST,
+            zone: Zone.DEEP_FOREST,
             description: "The cliff pulls away from the forest and, here, the forest does not follow, creating a rocky clearing.",
             killCount: 0,
             scoutThreshold: 1
@@ -368,13 +372,17 @@ export const useMapStore = defineStore('mapStuff', () => {
     }
 
     function callRandomEncounter(zone: Zone): void {
+        let list = [] as Array<Enemy>;
         switch(zone) {
             //TODO: Add Deep Forest Zone and spawn list!
-            case Zone.FOREST: {
-                const encounterIdx = Math.floor(Math.random() * enemyList.length );
+            case Zone.FOREST: { list = enemyList.get(Zone.FOREST) || [] }
+            case Zone.DEEP_FOREST: { list = enemyList.get(Zone.DEEP_FOREST) || [] }
+            case Zone.RIVERBANK: { list = enemyList.get(Zone.RIVERBANK) || [] }
 
+            if(!!list && list.length > 1) {
+                const encounterIdx = Math.floor(Math.random() * list.length );
                 const combatStore = useCombatStore();
-                combatStore.startCombat(enemyList[encounterIdx]);
+                combatStore.startCombat(list[encounterIdx]);
             }
         }
     }

--- a/src/stores/saveStore.ts
+++ b/src/stores/saveStore.ts
@@ -36,11 +36,13 @@ export const useSaveStore = defineStore('saveStore', () =>{
             spd: player.playerStats.spd
         },
         unlocks: {
-            playerUpgrades: [] as Array<SaveUpgradeArray>
+            playerUpgrades: [] as Array<SaveUpgradeArray>,
+            soulUpgrades: [] as Array<SaveUpgradeArray>
         },
         kills: [] as Array<SaveKillsArray>,
         totalKills: mapStore.totalKills,
-        gameFlags: [] as Array<SavedGameFlags>
+        gameFlags: [] as Array<SavedGameFlags>,
+        version: 1
     }
 
 
@@ -68,11 +70,14 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 spd: player.playerStats.spd
             },
             unlocks: {
-                playerUpgrades: [] as Array<SaveUpgradeArray>
+                playerUpgrades: [] as Array<SaveUpgradeArray>,
+                soulUpgrades: [] as Array<SaveUpgradeArray>
             },
             kills: [] as Array<SaveKillsArray>,
             totalKills: mapStore.totalKills,
-            gameFlags: [] as Array<SavedGameFlags>
+            gameFlags: [] as Array<SavedGameFlags>,
+            //Set a version for dealing with breaking changes to saves.
+            version: 1
         }
         //TODO: this only saves upgrades in the home category
         saveFile.unlocks.playerUpgrades = Array.from(upgrades.home.entries()).map((entry) => {
@@ -80,6 +85,14 @@ export const useSaveStore = defineStore('saveStore', () =>{
                 key: entry[0],
                 unlocked: entry[1].show,
                 bought: entry[1].bought,
+            } as SaveUpgradeArray
+        })
+        saveFile.unlocks.soulUpgrades = Array.from(upgrades.soul.entries()).map((entry) => {
+            return {
+                key: entry[0],
+                unlocked: entry[1].show,
+                bought: entry[1].bought,
+                level: entry[1].level || 1,
             } as SaveUpgradeArray
         })
         saveFile.kills = Array.from(mapStore.mapNodes).map((entry) => {
@@ -126,6 +139,15 @@ export const useSaveStore = defineStore('saveStore', () =>{
             if(temp) {
                 temp.show = item.unlocked;
                 temp.bought = item.bought;
+                upgrades.home.set(item.key, temp);
+            }
+        })
+        saveFile.unlocks.soulUpgrades.forEach(function(item) {
+            let temp = upgrades.soul.get(item.key);
+            if(temp) {
+                temp.show = item.unlocked;
+                temp.bought = item.bought;
+                temp.level = item.level || 1;
                 upgrades.home.set(item.key, temp);
             }
         })

--- a/src/stores/upgradeStore.ts
+++ b/src/stores/upgradeStore.ts
@@ -24,7 +24,105 @@ export const useUpgradeStore = defineStore('upgradeStore', {
         */
 
         //TODO: add this to saving functionality.
+        //TODO @Mak: set the show here to false and programmatically turn it on once you've got the events set up.
        soul: new Map<number, Upgrade>([
+            [1, {
+                show: true,
+                bought: false,
+                category: UpgradeCategory.SOUL,
+                title: "Soul ATK",
+                flavor: "TBD.",
+                effectDescription: "+1 attack. Can be bought multiple times.",
+                get costDescription() {
+                    return Math.pow(1.7, this.level).toFixed(2) + " Soul."
+                },
+                costFunc: (buyCheck: boolean, level?: number) => {
+                    const player = usePlayer();
+                    if(!level) { return false; }
+                    const cost = parseFloat(Math.pow(1.7, level).toPrecision(1))
+                    const canBuy = player.enoughSoul(cost)
+  
+                    if(buyCheck) {
+                        return canBuy
+                    } else if(!canBuy) {
+                        return false
+                    } else {
+                        player.subtractSoul(cost);
+                        return true;
+                    }
+
+                },
+                effect: function() {
+                    const player = usePlayer();
+                    player.addBaseAtk(1);
+                },
+                repeatable: true,
+                level: 1
+            }],
+            [2, {
+                show: true,
+                bought: false,
+                category: UpgradeCategory.SOUL,
+                title: "Soul DEF",
+                flavor: "TBD.",
+                effectDescription: "+1 defense. Can be bought multiple times.",
+                get costDescription() {
+                    return Math.pow(1.7, this.level).toFixed(2) + " Soul."
+                },
+                costFunc: (buyCheck: boolean, level?: number) => {
+                    const player = usePlayer();
+                    if(!level) { return false; }
+                    const cost = parseFloat(Math.pow(1.7, level).toPrecision(1))
+                    const canBuy = player.enoughSoul(cost)
+  
+                    if(buyCheck) {
+                        return canBuy
+                    } else if(!canBuy) {
+                        return false
+                    } else {
+                        player.subtractSoul(cost);
+                        return true;
+                    }
+                },
+                effect: function() {
+                    const player = usePlayer();
+                    player.addBaseDef(1);
+                },
+                repeatable: true,
+                level: 1
+            }],
+            [3, {
+                show: true,
+                bought: false,
+                category: UpgradeCategory.SOUL,
+                title: "Soul HP",
+                flavor: "TBD.",
+                effectDescription: "+5 HP. Can be bought multiple times.",
+                get costDescription() {
+                    return Math.pow(1.5, this.level).toFixed(2) + " Soul."
+                },
+                costFunc: (buyCheck: boolean, level?: number) => {
+                    const player = usePlayer();
+                    if(!level) { return false; }
+                    const cost = parseFloat(Math.pow(1.5, level).toPrecision(1))
+                    const canBuy = player.enoughSoul(cost)
+  
+                    if(buyCheck) {
+                        return canBuy
+                    } else if(!canBuy) {
+                        return false
+                    } else {
+                        player.subtractSoul(cost);
+                        return true;
+                    }
+                },
+                effect: function() {
+                    const player = usePlayer();
+                    player.addBaseHealth(5);
+                },
+                repeatable: true,
+                level: 1
+            }]
 
         ]),
         
@@ -36,7 +134,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 title: "Honed Instinct",
                 flavor: "You are becoming more familiar with the terrain, more sure of foot.",
                 effectDescription: "+1 defense.",
-                costDescription:"Requires 3 areas scouted.",
+                costDescription: "Requires 3 areas scouted.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
                     return player.enoughScouted(3);
@@ -53,7 +151,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 title: "Sharpen Claws",
                 flavor: "You let your claws dull before. You should fix that.",
                 effectDescription: "+1 attack.",
-                costDescription:"Requires 10 enemies killed.",
+                costDescription: "Requires 10 enemies killed.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
                     return player.enoughKills(10);
@@ -71,7 +169,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 title: "Adaptation",
                 flavor: "Despite your recent travels and bouts of combat, you feel... energized. Harder to wind, harder to bleed.",
                 effectDescription: "+10 HP.",
-                costDescription:"Requires 6 areas scouted.",
+                costDescription: "Requires 6 areas scouted.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
                     return player.enoughScouted(6);
@@ -89,19 +187,21 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 category: UpgradeCategory.HOME,
                 title: "Makeshift Bed",
                 flavor: "Scrounge up some sticks and soft things so you have something better to sleep on then the cold stone floor.",
-                effectDescription: "+0.5 HP/sec, +0.2 Energy/sec. True Cost is TBD",
-                costDescription:"Costs 10 Soul.",
+                effectDescription: "+0.5 HP/sec, +0.2 Energy/sec.",
+                costDescription: "Costs 5 Fiber and 5 Stone.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
-                    const canBuy = player.enoughSoul(10);
-                    if (buyCheck) {
-                        return canBuy;
-                    }
+                    const canBuy = player.checkResourceCost(5, ResourceEnum.FIBER) && player.checkResourceCost(5, ResourceEnum.STONE)
 
-                    if(canBuy) {
-                        player.subtractSoul(10);  
+                    if(buyCheck) {
+                        return canBuy
+                    } else if(!canBuy) {
+                        return false
+                    } else {
+                        player.payResource(5, ResourceEnum.FIBER)
+                        player.payResource(5, ResourceEnum.STONE)
+                        return true
                     }
-                    return canBuy;
                 },
                 effect: function() {
                     const player = usePlayer();
@@ -110,14 +210,14 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 }
 
             }],
-            [4,{
+            [5,{
                 show: false,
                 bought: false,
                 category: UpgradeCategory.HOME,
                 title: "Makeshift Rope",
                 flavor: "Find a long enough vine to wrap around the strange statue so you can drag it home.",
                 effectDescription: "Take this back to the Strange Clearing.",
-                costDescription:"Costs 5 Fiber.",
+                costDescription: "Costs 5 Fiber.",
                 costFunc: (buyCheck: boolean) => {
                     const player = usePlayer();
 

--- a/src/stores/upgradeStore.ts
+++ b/src/stores/upgradeStore.ts
@@ -34,7 +34,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 flavor: "TBD.",
                 effectDescription: "+1 attack. Can be bought multiple times.",
                 get costDescription() {
-                    return Math.pow(1.7, this.level).toFixed(2) + " Soul."
+                    return Math.pow(1.7, this.level || 1).toFixed(2) + " Soul."
                 },
                 costFunc: (buyCheck: boolean, level?: number) => {
                     const player = usePlayer();
@@ -67,7 +67,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 flavor: "TBD.",
                 effectDescription: "+1 defense. Can be bought multiple times.",
                 get costDescription() {
-                    return Math.pow(1.7, this.level).toFixed(2) + " Soul."
+                    return Math.pow(1.7, this.level || 1).toFixed(2) + " Soul."
                 },
                 costFunc: (buyCheck: boolean, level?: number) => {
                     const player = usePlayer();
@@ -99,7 +99,7 @@ export const useUpgradeStore = defineStore('upgradeStore', {
                 flavor: "TBD.",
                 effectDescription: "+5 HP. Can be bought multiple times.",
                 get costDescription() {
-                    return Math.pow(1.5, this.level).toFixed(2) + " Soul."
+                    return Math.pow(1.5, this.level|| 1).toFixed(2) + " Soul."
                 },
                 costFunc: (buyCheck: boolean, level?: number) => {
                     const player = usePlayer();

--- a/src/types/saveArrays.ts
+++ b/src/types/saveArrays.ts
@@ -2,6 +2,7 @@ export interface SaveUpgradeArray {
     key: number,
     unlocked: boolean,
     bought: boolean,
+    level: number
 }
 
 export interface SaveKillsArray {

--- a/src/types/upgrade.ts
+++ b/src/types/upgrade.ts
@@ -6,8 +6,10 @@ export interface Upgrade {
   flavor: string;
   effectDescription: string;
   costDescription: string;
-  costFunc: (buyCheck: boolean) => boolean;
+  costFunc(buyCheck: boolean, level?: number): boolean;
   effect: Function;
+  repeatable?: boolean;
+  level?: number; //how many times the upgrade has been bought?
 }
 
 export enum UpgradeCategory {


### PR DESCRIPTION
This PR adds Soul Upgrades and a few things around new zones:

- Add Soul Upgrades. These are repeatable upgrades that can be bought multiple times. Add some styling/structure/logic changes for them.
- Add custom styling per zone for each node.
- Add two new Zones: Deep Forest and Riverbank.
- Add basic placeholder enemy lists for the new zones, and alter random encounter function to work with this.